### PR TITLE
strip exif data from CropEntropy thumbnails

### DIFF
--- a/php-classes/Media.class.php
+++ b/php-classes/Media.class.php
@@ -317,6 +317,7 @@ class Media extends ActiveRecord
             }
             $croppedImage = $cropper->resizeAndCrop($thumbWidth, $thumbHeight);
             $croppedImage->stripImage();
+            $croppedImage->setImageCompressionQuality(static::$thumbnailJPEGCompression);
             $croppedImage->writeImage($thumbPath);
         } else {
             // load source image

--- a/php-classes/Media.class.php
+++ b/php-classes/Media.class.php
@@ -316,7 +316,8 @@ class Media extends ActiveRecord
                 $cropper = new stojg\crop\CropEntropy($this->FilesystemPath);
             }
             $croppedImage = $cropper->resizeAndCrop($thumbWidth, $thumbHeight);
-            $croppedImage->writeimage($thumbPath);
+            $croppedImage->stripImage();
+            $croppedImage->writeImage($thumbPath);
         } else {
             // load source image
             $srcImage = $this->getImage();


### PR DESCRIPTION
results in much smaller thumbnail sizes in some cases, but the loss of color profiles makes a lot of professional headshots look worse. Perhaps there's a way to collapse the color profile data into the outputted image? Or maybe color profiles can be left and other exif data stripped?

Extreme example is this thumbnail which is >700KB without the exif data stripped: http://2015.phillytechweek.com/thumbnail/1494/120x120/cropped
