### PR TITLE
Add local table alias to join statements

### DIFF
--- a/php-classes/ActiveRecord.class.php
+++ b/php-classes/ActiveRecord.class.php
@@ -1123,6 +1123,7 @@ class ActiveRecord
 
 		
 		// handle joining related tables
+		$tableAlias = static::getTableAlias();
 		$join = '';
 		if($options['joinRelated'])
 		{
@@ -1144,7 +1145,7 @@ class ActiveRecord
 				{
 					case 'one-one':
 					{
-						$join .= sprintf(' JOIN `%1$s` AS `%2$s` ON(`%2$s`.`%3$s` = `%4$s`)', $rel['class']::$tableName, $rel['class']::getTableAlias(), $rel['foreign'], $rel['local']);
+						$join .= sprintf(' JOIN `%1$s` AS `%2$s` ON(`%2$s`.`%3$s` = `%4$s`.`%5$s`)', $rel['class']::$tableName, $rel['class']::getTableAlias(), $rel['foreign'], $tableAlias, $rel['local']);
 						break;
 					}
 					default:
@@ -1194,7 +1195,7 @@ class ActiveRecord
 		$params = array(
 			$options['calcFoundRows'] ? 'SQL_CALC_FOUND_ROWS' : ''
 			, static::$tableName
-			, static::getTableAlias()
+			, $tableAlias
 			, $join
 			, $conditions ? join(') AND (', $conditions) : '1'
 		);


### PR DESCRIPTION
This commit fixes the `Ambiguous column name` Query Exception thrown when joining a class with a common field name.
e.g. Joining Creator in most classes will cause an error, since most classes have the common `CreatorID` column being used by join statement.