### PR TITLE
Add 'original' as valid media variant.

### DIFF
--- a/php-classes/Media.class.php
+++ b/php-classes/Media.class.php
@@ -665,6 +665,12 @@ class Media extends ActiveRecord
 
     public function isVariantAvailable($variant)
     {
-        return false;
+        switch ($variant) {
+            case 'original':
+                return true;
+            
+            default:
+                return false;
+        }
     }
 }


### PR DESCRIPTION
This allows for urls like: /media/1/original/filename.mp4 to be valid.
