### PR TITLE
Tag search

### DIFF
--- a/php-classes/Tag.class.php
+++ b/php-classes/Tag.class.php
@@ -43,10 +43,18 @@ class Tag extends ActiveRecord
             'qualifiers' => array('prefix')
             ,'points' => 2
             ,'sql' => 'Handle LIKE "%%%s%%.%"'
+        ),
+        'Title' => array(
+            'qualifiers' => ['any', 'Title'],
+            'points' => 1,
+            'sql' => 'Title LIKE "%%%1$s%%"'
+        ),
+        'Handle' => array(
+            'qualifiers' => ['any', 'Handle'],
+            'points' => 1,
+            'sql' => 'Handle LIKE "%%%1$s%%"'
         )
     );
-
-
 
     // public methods
     public static function assignTags($contextClass, $contextID, $tags, $autoCreate = true)

--- a/php-classes/Tag.class.php
+++ b/php-classes/Tag.class.php
@@ -45,12 +45,12 @@ class Tag extends ActiveRecord
             ,'sql' => 'Handle LIKE "%%%s%%.%"'
         ),
         'Title' => array(
-            'qualifiers' => ['any', 'Title'],
+            'qualifiers' => ['any', 'title'],
             'points' => 1,
             'sql' => 'Title LIKE "%%%1$s%%"'
         ),
         'Handle' => array(
-            'qualifiers' => ['any', 'Handle'],
+            'qualifiers' => ['any', 'handle'],
             'points' => 1,
             'sql' => 'Handle LIKE "%%%1$s%%"'
         )

--- a/php-classes/TagsRequestHandler.class.php
+++ b/php-classes/TagsRequestHandler.class.php
@@ -21,7 +21,22 @@ class TagsRequestHandler extends RecordsRequestHandler
             }
         }
     }
+    
+    public static function handleBrowseRequest($options = array(), $conditions = array(), $responseID = NULL, $responseData = array())
+    {
+        if (!empty($_REQUEST['q']) && $_REQUEST['valuesqry'] == 'true') {
+            $handles = explode('|', $_REQUEST['q']);
+            $conditions = 'Handle IN ("'.join('","',DB::escape($handles)).'")';
+            
+            return static::respond('tags', array(
+                'success' => true
+                ,'data' => Tag::getAllByWhere($conditions)
+            ));
+        }
 
+        return parent::handleBrowseRequest($options, $conditions, $responseID, $responseData);
+    }
+    
     public static function handleRecordRequest(ActiveRecord $Tag, $action = false)
     {
         switch ($action ? $action : $action = static::shiftPath()) {

--- a/php-classes/TagsRequestHandler.class.php
+++ b/php-classes/TagsRequestHandler.class.php
@@ -7,7 +7,6 @@ class TagsRequestHandler extends RecordsRequestHandler
     public static $accountLevelBrowse = false;
     public static $accountLevelAssign = 'User';
 
-
     public static function handleRecordsRequest($action = false)
     {
         switch ($action ? $action : $action = static::shiftPath()) {
@@ -22,29 +21,6 @@ class TagsRequestHandler extends RecordsRequestHandler
             }
         }
     }
-
-
-    public static function handleBrowseRequest($options = array(), $conditions = array(), $responseID = NULL, $responseData = array())
-    {
-        $conditions = array();
-
-        if (!empty($_REQUEST['q'])) {
-            if ($_REQUEST['valuesqry'] == 'true') {
-                $handles = explode('|', $_REQUEST['q']);
-                $conditions = 'Handle IN ("'.join('","',DB::escape($handles)).'")';
-            } elseif (ctype_digit($_REQUEST['q'])) {
-                $conditions[] = 'ID = '.$_REQUEST['q'];
-            } else {
-                $conditions[] = sprintf('Title LIKE "%%%1$s%%" OR Handle LIKE "%%%1$s%%"', DB::escape($_REQUEST['q']));
-            }
-        }
-
-        return static::respond('tags', array(
-            'success' => true
-            ,'data' => Tag::getAllByWhere($conditions)
-        ));
-    }
-
 
     public static function handleRecordRequest(ActiveRecord $Tag, $action = false)
     {
@@ -71,14 +47,12 @@ class TagsRequestHandler extends RecordsRequestHandler
             $conditions['ContextClass'] = $_REQUEST['Class'];
         }
 
-
         return static::respond('tagItems', array(
             'success' => true
             ,'data' => TagItem::getAllByWhere($conditions)
         ));
     }
-
-
+    
     public static function handleMultiAssignRequest()
     {
         if (static::$accountLevelAssign) {
@@ -107,7 +81,6 @@ class TagsRequestHandler extends RecordsRequestHandler
                 $results[] = $TagItem;
             }
         }
-
 
         return static::respond($className::$pluralNoun.'Saved', array(
             'success' => true


### PR DESCRIPTION
@themightychris 

The query override on the tag request handler was preventing me from sorting tags. I've added the Title and Handle search terms to the Tag class and trimmed down the browse request override to only fire if the valuesqry param is provided. From the looks of it all of the previous functionality should be available but now we also have rest of the standard query functionality provided by the request handler.

Let me know what you think.
