### PR TITLE
Mysql 5.7 migrations

### DIFF
--- a/php-classes/Emergence/SiteAdmin/MigrationsRequestHandler.php
+++ b/php-classes/Emergence/SiteAdmin/MigrationsRequestHandler.php
@@ -214,8 +214,14 @@ class MigrationsRequestHandler extends \RequestHandler
         return DB::oneValue('SELECT COLUMN_KEY FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = SCHEMA() AND TABLE_NAME = "%s" AND COLUMN_NAME = "%s"', DB::escape([$tableName, $columnName]));
     }
 
+    protected static function getColumnDefault($tableName, $columnName)
+    {
+        return DB::oneValue('SELECT COLUMN_DEFAULT FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = SCHEMA() AND TABLE_NAME = "%s" AND COLUMN_NAME = "%s"', DB::escape([$tableName, $columnName]));
+    }
+
     protected static function getColumnIsNullable($tableName, $columnName)
     {
         return 'YES' == DB::oneValue('SELECT IS_NULLABLE FROM information_schema.COLUMNS WHERE TABLE_SCHEMA = SCHEMA() AND TABLE_NAME = "%s" AND COLUMN_NAME = "%s"', DB::escape([$tableName, $columnName]));
     }
+
 }

--- a/php-migrations/Emergence/Connectors/20170322_results-nullable.php
+++ b/php-migrations/Emergence/Connectors/20170322_results-nullable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Emergence\Connectors;
+
+use DB;
+
+// skip conditions
+if (!static::tableExists(Job::$tableName)) {
+    printf("Skipping migration because table `%s` does not exist yet\n", Job::$tableName);
+    return static::STATUS_SKIPPED;
+}
+
+if (static::getColumnIsNullable(Job::$tableName, 'Results')) {
+    printf("Skipping migration because column `Results` is already nullable\n");
+    return static::STATUS_SKIPPED;
+}
+
+// migration
+DB::nonQuery('ALTER TABLE `%s` CHANGE `Results` `Results` TEXT NULL default NULL', Job::$tableName);
+
+// done
+return static::STATUS_EXECUTED;

--- a/php-migrations/Emergence/Connectors/20170322_title-nullable.php
+++ b/php-migrations/Emergence/Connectors/20170322_title-nullable.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Emergence\Connectors;
+
+use DB;
+
+// skip conditions
+if (!static::tableExists(Job::$tableName)) {
+    printf("Skipping migration because table `%s` does not exist yet\n", Job::$tableName);
+    return static::STATUS_SKIPPED;
+}
+
+if (static::getColumnIsNullable(Job::$tableName, 'Title')) {
+    printf("Skipping migration because column `Title` is already nullable\n");
+    return static::STATUS_SKIPPED;
+}
+
+// migration
+DB::nonQuery('ALTER TABLE `%s` CHANGE `Title` `Title` VARCHAR(255) NULL default NULL', Job::$tableName);
+
+// done
+return static::STATUS_EXECUTED;


### PR DESCRIPTION
- Create migration script to convert connector job fields (`Results`, `Title`) to nullable.
- Add shortcut method for getting column's default value