### PR TITLE
Update git path regex to accept quoted spaces

### DIFF
--- a/php-classes/Emergence/Git/Source.php
+++ b/php-classes/Emergence/Git/Source.php
@@ -408,7 +408,7 @@ class Source
                 continue; // skip comment lines
             }
 
-            if (!preg_match('/^(?<indexStatus>[ MADRCU?!])(?<workTreeStatus>[ MADRCU?!]) (?<path>\S+)( -> (?<renamePath>\S+))?$/', $line, $matches)) {
+            if (!preg_match('/^(?<indexStatus>[ MADRCU?!])(?<workTreeStatus>[ MADRCU?!]) (?<path>(?:"([\S ]+)"|(\S+)))( -> (?<renamePath>\S+))?$/', $line, $matches)) {
                 throw new \Exception('Could not parse git status output line: ' . $line);
             }
 


### PR DESCRIPTION
Apparently, paths can come in the format of:

- `this/is/a/file.txt`
- `"this/is also/a/file.txt"`