### PR TITLE
Implement the ability to ignore deep saving of specific relationships

### DIFF
--- a/php-classes/ActiveRecord.class.php
+++ b/php-classes/ActiveRecord.class.php
@@ -949,7 +949,7 @@ class ActiveRecord
     {
         // save relationship objects
         foreach (static::getStackedConfig('relationships') AS $relationship => $options) {
-            if (isset($options['ignoreDeepSave'])) {
+            if (!empty($options['ignoreDeepSave'])) {
                 continue;
             }
 
@@ -990,7 +990,7 @@ class ActiveRecord
         //die('psr');
         // save relationship objects
         foreach (static::getStackedConfig('relationships') AS $relationship => $options) {
-            if (isset($options['ignoreDeepSave']) || !isset($this->_relatedObjects[$relationship])) {
+            if (!empty($options['ignoreDeepSave']) || !isset($this->_relatedObjects[$relationship])) {
                 continue;
             }
 

--- a/php-classes/ActiveRecord.class.php
+++ b/php-classes/ActiveRecord.class.php
@@ -949,6 +949,10 @@ class ActiveRecord
     {
         // save relationship objects
         foreach (static::getStackedConfig('relationships') AS $relationship => $options) {
+            if (isset($options['ignoreDeepSave'])) {
+                continue;
+            }
+
             if ($options['type'] == 'one-one') {
                 if (isset($this->_relatedObjects[$relationship])) {
                     $this->_relatedObjects[$relationship]->save();
@@ -986,7 +990,7 @@ class ActiveRecord
         //die('psr');
         // save relationship objects
         foreach (static::getStackedConfig('relationships') AS $relationship => $options) {
-            if (!isset($this->_relatedObjects[$relationship])) {
+            if (isset($options['ignoreDeepSave']) || !isset($this->_relatedObjects[$relationship])) {
                 continue;
             }
 


### PR DESCRIPTION
- Use `ActiveRecord`'s `$relationship` config to disable deep saving of relationships. 