### PR TITLE
Release: emergence-skeleton v1.4.4

### DIFF
--- a/html-templates/site-admin/dashboard.tpl
+++ b/html-templates/site-admin/dashboard.tpl
@@ -6,9 +6,9 @@
 {/block}
 
 {block content}
-    <div class="page-header">
+    <header class="row">
         <h1>Site Dashboard</h1>
-    </div>
+    </header>
 
     <dl class="row">
         {foreach item=metric from=$metrics}
@@ -29,5 +29,16 @@
                 {/if}
             </dd>
         {/foreach}
+    </dl>
+
+    <header class="row">
+        <h2>Exports</h2>
+    </header>
+
+    <dl class="row">
+        <dt class="col-3 text-right">Database</dt>
+        <dd class="col-9">
+            <a href="/site-admin/database/dump.sql" class="btn btn-sm btn-outline-info">Download .sql dump</a>
+        </dd>
     </dl>
 {/block}

--- a/html-templates/site-admin/dashboard.tpl
+++ b/html-templates/site-admin/dashboard.tpl
@@ -38,7 +38,7 @@
     <dl class="row">
         <dt class="col-3 text-right">Database</dt>
         <dd class="col-9">
-            <a href="/site-admin/database/dump.sql" class="btn btn-sm btn-outline-info">Download .sql dump</a>
+            <a href="/site-admin/database/dump.sql?$session={$.Session->Handle}" class="btn btn-sm btn-outline-info">Download .sql dump</a>
         </dd>
     </dl>
 {/block}

--- a/html-templates/site-admin/dashboard.tpl
+++ b/html-templates/site-admin/dashboard.tpl
@@ -38,7 +38,7 @@
     <dl class="row">
         <dt class="col-3 text-right">Database</dt>
         <dd class="col-9">
-            <a href="/site-admin/database/dump.sql?$session={$.Session->Handle}" class="btn btn-sm btn-outline-info">Download .sql dump</a>
+            <a href="/site-admin/database/dump.sql?_session={$.Session->Handle}" class="btn btn-sm btn-outline-info">Download .sql dump</a>
         </dd>
     </dl>
 {/block}

--- a/php-classes/Authenticator.class.php
+++ b/php-classes/Authenticator.class.php
@@ -1,33 +1,29 @@
 <?php
 
-
-
- abstract class Authenticator
- {
-     // abstract functions
+abstract class Authenticator
+{
+    // abstract functions
     abstract public function requireAuthentication();
-     abstract public function checkAuthentication();
-     abstract protected function getAuthenticatedPerson();
+    abstract public function checkAuthentication();
+    abstract protected function getAuthenticatedPerson();
 
-    // protected 
+    // protected
     protected $_session;
-     protected $_authenticatedPerson;
+    protected $_authenticatedPerson;
 
-     public function __construct(Session $Session)
-     {
-         // store session
+    public function __construct(Session $Session)
+    {
+        // store session
         $this->_session = $Session;
-     }
+    }
 
-
-     public function __get($name)
-     {
-         switch ($name) {
+    public function __get($name)
+    {
+        switch ($name) {
             case 'Session':
                 return $this->_session;
 
             case 'AuthenticatedPerson':
-
                 if (!isset($this->_authenticatedPerson)) {
                     $this->_authenticatedPerson = $this->getAuthenticatedPerson();
                 }
@@ -37,5 +33,5 @@
             default:
                 return null;
         }
-     }
- }
+    }
+}

--- a/php-classes/Emergence/DAV/DevelopRequestHandler.php
+++ b/php-classes/Emergence/DAV/DevelopRequestHandler.php
@@ -35,7 +35,7 @@ class DevelopRequestHandler extends \RequestHandler
             $authUserPass = $authEngine->getUserPass();
 
             // try to get session
-            if ($authUserPass[0] == '$session') {
+            if ($authUserPass[0] == '$session' || $authUserPass[0] == '_session') {
                 if ($Session = UserSession::getByHandle($authUserPass[1])) {
                     $User = $Session->Person;
                 }

--- a/php-classes/Emergence/SiteAdmin/DashboardRequestHandler.php
+++ b/php-classes/Emergence/SiteAdmin/DashboardRequestHandler.php
@@ -2,11 +2,11 @@
 
 namespace Emergence\SiteAdmin;
 
+use DB;
 use Site;
 use Person;
 use User;
 use Emergence\Util\ByteSize;
-
 
 class DashboardRequestHandler extends \RequestHandler
 {
@@ -105,6 +105,18 @@ class DashboardRequestHandler extends \RequestHandler
                 [
                     'label' => 'Host Load Average',
                     'value' => implode(' ', array_map(function ($n) { return number_format($n, 2); }, sys_getloadavg()))
+                ],
+                [
+                    'label' => 'Database tables',
+                    'value' => DB::oneValue(
+                        '
+                            SELECT COUNT(*)
+                              FROM information_schema.tables
+                             WHERE TABLE_SCHEMA = SCHEMA()
+                               AND TABLE_NAME NOT IN ("%s")
+                        ',
+                        implode('","', DatabaseRequestHandler::getExcludeTables())
+                    )
                 ]
             ]
         ]);

--- a/php-classes/Emergence/SiteAdmin/DatabaseRequestHandler.php
+++ b/php-classes/Emergence/SiteAdmin/DatabaseRequestHandler.php
@@ -89,7 +89,8 @@ class DatabaseRequestHandler extends \RequestHandler
             [
                 'exclude-tables' => static::getExcludeTables(),
                 'skip-comments' => !isset($_GET['comments']),
-                'skip-definer' => !isset($_GET['definer'])
+                'skip-definer' => !isset($_GET['definer']),
+                'add-drop-table' => true
             ]
         );
 

--- a/php-classes/Emergence/SiteAdmin/DatabaseRequestHandler.php
+++ b/php-classes/Emergence/SiteAdmin/DatabaseRequestHandler.php
@@ -7,6 +7,8 @@ use Ifsnop\Mysqldump\Mysqldump;
 
 class DatabaseRequestHandler extends \RequestHandler
 {
+    public static $excludeTables = ['sessions', '_e_files', '_e_file_collections'];
+
     public static $userResponseModes = [
         'application/json' => 'json'
     ];
@@ -49,6 +51,11 @@ class DatabaseRequestHandler extends \RequestHandler
         ];
     }
 
+    public static function getExcludeTables()
+    {
+        return static::$excludeTables;
+    }
+
     public static function handleDumpRequest()
     {
         $connectionConfig = static::getConnectionConfig();
@@ -59,7 +66,7 @@ class DatabaseRequestHandler extends \RequestHandler
             $connectionConfig['username'],
             $connectionConfig['password'],
             [
-                'exclude-tables' => ['sessions', '_e_files', '_e_file_collections'],
+                'exclude-tables' => static::getExcludeTables(),
                 'skip-comments' => !isset($_GET['comments']),
                 'skip-definer' => !isset($_GET['definer'])
             ]

--- a/php-classes/JSON.class.php
+++ b/php-classes/JSON.class.php
@@ -20,7 +20,13 @@ class JSON
         }
 
         if (
-            (!empty($_GET['$profile']) || !empty($_COOKIE['$profile']) || !empty($_SERVER['HTTP_X_PROFILE']))
+            (
+                !empty($_GET['$profile']) // TODO: deprecate
+                || !empty($_COOKIE['$profile']) // TODO: deprecate
+                || !empty($_GET['_profile'])
+                || !empty($_COOKIE['_profile'])
+                || !empty($_SERVER['HTTP_X_PROFILE'])
+            )
             && !empty($GLOBALS['Session'])
             && $GLOBALS['Session']->hasAccountLevel('Developer')
         ) {
@@ -101,7 +107,7 @@ class JSON
     {
         if (is_object($input)) {
             if (
-                !empty($include) && 
+                !empty($include) &&
                 $summary ? method_exists($input, 'getSummary') : method_exists($input, 'getDetails')
             ) {
                 $includeThisLevel = array();

--- a/php-classes/JSON.class.php
+++ b/php-classes/JSON.class.php
@@ -21,9 +21,7 @@ class JSON
 
         if (
             (
-                !empty($_GET['$profile']) // TODO: deprecate
-                || !empty($_COOKIE['$profile']) // TODO: deprecate
-                || !empty($_GET['_profile'])
+                !empty($_GET['_profile'])
                 || !empty($_COOKIE['_profile'])
                 || !empty($_SERVER['HTTP_X_PROFILE'])
             )
@@ -34,7 +32,7 @@ class JSON
             $siteDataPrefix = Site::$rootPath.'/'.SiteFile::$dataPath.'/';
             $siteDataPrefixLength = strlen($siteDataPrefix);
 
-            $data['$profile'] = array(
+            $data['_profile'] = array(
                 'log' => Debug::$log,
                 'time' => array(
                     'initialized' => Site::$initializeTime,

--- a/php-classes/PasswordAuthenticator.class.php
+++ b/php-classes/PasswordAuthenticator.class.php
@@ -1,6 +1,5 @@
 <?php
 
-
 class PasswordAuthenticator extends Authenticator
 {
     // configurable settings
@@ -30,7 +29,7 @@ class PasswordAuthenticator extends Authenticator
             if (isset($_REQUEST[static::$requestContainer])) {
                 $requestData = &$_REQUEST[static::$requestContainer];
             } else {
-                $requestData = array();
+                $requestData = [];
             }
         } else {
             $requestData = &$_POST;
@@ -41,11 +40,11 @@ class PasswordAuthenticator extends Authenticator
             $this->_authenticatedPerson = $this->attemptAuthentication($requestData['username'], $requestData['password']);
 
             if ($this->_authenticatedPerson) {
-                Emergence\EventBus::fireEvent('personAuthenticate', 'Emergence/People', array(
+                Emergence\EventBus::fireEvent('personAuthenticate', 'Emergence/People', [
                     'Person' => $this->_authenticatedPerson,
                     'requestData' => $requestData,
                     'authenticatorClass' => get_called_class()
-                ));
+                ]);
 
                 // redirect if original request was GET
                 if ($requestData['returnMethod'] != 'POST' && $_SERVER['REQUEST_METHOD'] != 'GET') {
@@ -70,8 +69,8 @@ class PasswordAuthenticator extends Authenticator
     protected function getAuthenticatedPerson()
     {
         // check if session is already authenticated
-        if (isset($this->$_authenticatedPerson)) {
-            return $this->$_authenticatedPerson;
+        if (isset($this->_authenticatedPerson)) {
+            return $this->_authenticatedPerson;
         } elseif ($this->_session->PersonID) {
             return Person::getByID($this->_session->PersonID);
         } else {
@@ -93,9 +92,9 @@ class PasswordAuthenticator extends Authenticator
             return null;
         }
 
-        $this->_session = $this->_session->changeClass('UserSession', array(
+        $this->_session = $this->_session->changeClass(UserSession::class, [
             'PersonID' => $User->ID
-        ));
+        ]);
 
         return $User;
     }
@@ -122,11 +121,9 @@ class PasswordAuthenticator extends Authenticator
             return false;
         }
 
-
         if (!$success) {
             $this->respondLoginPrompt();
         }
-
 
         return $success;
     }
@@ -152,12 +149,12 @@ class PasswordAuthenticator extends Authenticator
         $postVars = $_POST;
         unset($postVars[static::$requestContainer]);
 
-        RequestHandler::respond('login/login', array(
-            'success' => false
-            ,'loginRequired' => true
-            ,'requestContainer' => static::$requestContainer
-            ,'error' => $authException ? $authException->getMessage() : false
-            ,'postVars' => $postVars
-        ));
+        RequestHandler::respond('login/login', [
+            'success' => false,
+            'loginRequired' => true,
+            'requestContainer' => static::$requestContainer,
+            'error' => $authException ? $authException->getMessage() : false,
+            'postVars' => $postVars
+        ]);
     }
 }

--- a/php-classes/Session.class.php
+++ b/php-classes/Session.class.php
@@ -76,8 +76,8 @@ class Session extends ActiveRecord
         // try to load from POST data
         if (
             !$Session
-            && !empty($_POST['$session'])
-            && ($Session = static::getByHandle($_POST['$session']))
+            && !empty($_POST['_session'])
+            && ($Session = static::getByHandle($_POST['_session']))
         ) {
             $Session = static::updateSession($Session, $sessionData);
         }
@@ -95,8 +95,8 @@ class Session extends ActiveRecord
         // try to load from GET data
         if (
             !$Session
-            && !empty($_GET['$session'])
-            && ($Session = static::getByHandle($_GET['$session']))
+            && !empty($_GET['_session'])
+            && ($Session = static::getByHandle($_GET['_session']))
         ) {
             $Session = static::updateSession($Session, $sessionData);
         }

--- a/php-classes/Session.class.php
+++ b/php-classes/Session.class.php
@@ -76,19 +76,39 @@ class Session extends ActiveRecord
         // try to load from POST data
         if (
             !$Session
-            && !empty($_POST[static::$cookieName])
-            && ($Session = static::getByHandle($_POST[static::$cookieName]))
+            && !empty($_POST['$session'])
+            && ($Session = static::getByHandle($_POST['$session']))
         ) {
             $Session = static::updateSession($Session, $sessionData);
         }
 
+        if (
+            !$Session
+            && !empty($_POST[static::$cookieName])
+            && ($Session = static::getByHandle($_POST[static::$cookieName]))
+        ) {
+            $Session = static::updateSession($Session, $sessionData);
+
+            Emergence\Logger::general_warning('Deprecated use of cookieName via POST');
+        }
+
         // try to load from GET data
+        if (
+            !$Session
+            && !empty($_GET['$session'])
+            && ($Session = static::getByHandle($_GET['$session']))
+        ) {
+            $Session = static::updateSession($Session, $sessionData);
+        }
+
         if (
             !$Session
             && !empty($_GET[static::$cookieName])
             && ($Session = static::getByHandle($_GET[static::$cookieName]))
         ) {
             $Session = static::updateSession($Session, $sessionData);
+
+            Emergence\Logger::general_warning('Deprecated use of cookieName via GET');
         }
 
         // try to load from cookie data

--- a/php-classes/UserSession.class.php
+++ b/php-classes/UserSession.class.php
@@ -1,76 +1,72 @@
 <?php
 
-
-
- class UserSession extends Session
- {
+class UserSession extends Session
+{
      // ActiveRecord configuration
-    public static $subClasses = array('Session','UserSession');
+    public static $subClasses = [
+        Session::class,
+        __CLASS__
+    ];
 
-     public static $fields = array(
-        'PersonID' => array(
-            'type' => 'integer'
-            ,'unsigned' => true
-        )
-    );
+    public static $fields = [
+        'PersonID' => 'uint'
+    ];
 
-     public static $relationships = array(
-        'Person' => array(
-            'type' => 'one-one'
-            ,'class' => 'Person'
-            ,'local' => 'PersonID'
-        )
-    );
+    public static $relationships = [
+        'Person' => [
+            'type' => 'one-one',
+            'class' => Person::class
+        ]
+    ];
 
-     public static $dynamicFields = array(
+    public static $dynamicFields = [
         'Person'
-    );
+    ];
 
 
     // UserSession
     public static $requireAuthentication = false;
-     public static $defaultAuthenticator = 'PasswordAuthenticator';
-     public $authenticator;
+    public static $defaultAuthenticator = PasswordAuthenticator::class;
 
-     public function __construct($record = array())
-     {
+    public $authenticator;
+
+    public function __construct(array $record = [])
+    {
          parent::__construct($record);
 
-         if (!isset($this->authenticator)) {
-             $this->authenticator = new static::$defaultAuthenticator($this);
-         }
+        if (!isset($this->authenticator)) {
+            $this->authenticator = new static::$defaultAuthenticator($this);
+        }
 
         // check authentication
         $this->authenticator->checkAuthentication();
 
         // require authentication ?
-        if (static::$requireAuthentication) {
-            if (!$this->requireAuthentication()) {
-                throw new AuthenticationFailedException();
-            }
+        if (static::$requireAuthentication && !$this->requireAuthentication()) {
+            throw new AuthenticationFailedException();
         }
 
         // export data to _SESSION superglobal
         $_SESSION['User'] = $this->Person ? $this->Person : false;
-     }
+    }
 
-     public function requireAuthentication()
-     {
-         return $this->authenticator->requireAuthentication();
-     }
+    public function requireAuthentication()
+    {
+        return $this->authenticator->requireAuthentication();
+    }
 
-     public function requireAccountLevel($accountLevel)
-     {
-         $this->requireAuthentication();
+    public function requireAccountLevel($accountLevel)
+    {
+        $this->requireAuthentication();
 
-         if (!is_a($this->Person, 'User') || !$this->Person->hasAccountLevel($accountLevel)) {
-             ErrorHandler::handleInadaquateAccess($accountLevel);
-             exit();
-         }
-     }
+        if (!is_a($this->Person, User::class) || !$this->Person->hasAccountLevel($accountLevel)) {
+            ErrorHandler::handleInadaquateAccess($accountLevel);
+            exit();
+        }
+    }
 
-     public function hasAccountLevel($accountLevel)
-     {
-         return $this->Person && $this->Person->hasAccountLevel($accountLevel);
-     }
- }
+    public function hasAccountLevel($accountLevel)
+    {
+        return $this->Person && $this->Person->hasAccountLevel($accountLevel);
+    }
+}


### PR DESCRIPTION
- feat: deprecate $profile in favor of _profile
- feat: add drop table statements to dumps
- Use _session instead of $session for meta-params for better shell pasting
- feat: add support for HTTP Basic auth via developer account for database dump endpoint
- feat: include session in database download link via GET param
- feat: add $session as generic GET/POST param and deprecate using cookieName for them
- style: clean up syntax/format
- feat: add exports section with database dump button to site dashboard
- feat: add database tables count metric to site dashboard
- refactor: make excluded tables configurable and publicly accessible