### PR TITLE
Release: emergence-skeleton v1.4.7

### DIFF
--- a/.holo/branches/emergence-legacy/sencha-workspace/ext.toml
+++ b/.holo/branches/emergence-legacy/sencha-workspace/ext.toml
@@ -1,0 +1,7 @@
+[holomapping]
+holosource = "extjs"
+files = [
+    "**/*",
+    "!build/"
+]
+after = [ "skeleton-v1" ]


### PR DESCRIPTION
- chore: copy ext framework mapping to legacy holobranch