### PR TITLE
Release: emergence-skeleton v1.5.3

### DIFF
--- a/html-templates/designs/site.tpl
+++ b/html-templates/designs/site.tpl
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 {load_templates designs/site.subtemplates.tpl}
-{block "before-all"}{/block}
 <html class="no-js" lang="en">
 
 <head>

--- a/html-templates/webapps/EmergenceContentEditor/sencha.tpl
+++ b/html-templates/webapps/EmergenceContentEditor/sencha.tpl
@@ -1,10 +1,5 @@
 {extends designs/site.tpl}
 
-{block "before-all"}
-    {$app = Emergence\CMS\WebApp::load()}
-    {$dwoo.parent}
-{/block}
-
 {block "meta-rendering"}
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=10, user-scalable=yes">
@@ -12,15 +7,18 @@
 
 {block "css"}
     {$dwoo.parent}
+    {$app = $app|default:Emergence\CMS\WebApp::load()}
     {$app->buildCssMarkup()}
 {/block}
 
-{block content}
+{block "content"}
     <div id="app-viewport">Loading content editor&hellip;</div>
 {/block}
 
 {block "js-bottom"}
     {$dwoo.parent}
+
+    {$app = $app|default:Emergence\CMS\WebApp::load()}
 
     {$app->buildDataMarkup()}
 

--- a/php-classes/Emergence/WebApps/SenchaApp.php
+++ b/php-classes/Emergence/WebApps/SenchaApp.php
@@ -106,6 +106,9 @@ class SenchaApp extends App
 
         // patch manifest paths
         $html[] = '<script type="text/javascript">';
+        $html[] = 'window.Ext = window.Ext || {}';
+        $html[] = 'Ext.manifest = Ext.manifest || {}';
+        $html[] = 'Ext.manifest.resources = Ext.manifest.resources || {}';
         $html[] = 'Ext.manifest.resources.path = '.json_encode($this->getUrl().'/resources');
         $html[] = '</script>';
 


### PR DESCRIPTION
- fix: ensure manifest path exists before writing resource.path
- fix: remove dependence on new before-all template block to load CMS