### PR TITLE
Release: emergence-skeleton v1.6.0

### DIFF
--- a/html-templates/api-docs/openAPI.tpl
+++ b/html-templates/api-docs/openAPI.tpl
@@ -72,7 +72,7 @@
     <div class="split-view">
         <div class="nav-view">
             <ul class="docs-toc">
-                <li><a href="/">&larr; {Site::getConfig(label)}</a></li>
+                <li><a href="/">&larr; {$.Site.title|escape}</a></li>
                 <li><a href="#overview">Overview</a></li>
                 <li><a href="#keys">API Keys</a></li>
                 {if count($paths)}

--- a/php-classes/Emergence/Dwoo/Template.php
+++ b/php-classes/Emergence/Dwoo/Template.php
@@ -64,12 +64,21 @@ class Template extends \Dwoo_Template_String
         return file_get_contents($this->node->RealPath);
     }
 
-    public static function findNode($path, $throwExceptionOnNotFound = true)
+    public static function findNode($path, $throwExceptionOnNotFound = true, $context = null)
     {
         $templateNode = null;
 
-        $path = Site::splitPath($path);
-        $searchStack = array_filter(Site::$requestPath);
+        if (is_string($path)) {
+            $path = Site::splitPath($path);
+        }
+
+        if (is_string($context)) {
+            $context = Site::splitPath($context);
+        } elseif (!$context) {
+            $context = Site::$requestPath;
+        }
+
+        $searchStack = array_filter($context);
         array_unshift($searchStack, 'html-templates');
 
         if ($searchScriptname = array_pop($searchStack)) {

--- a/php-classes/Emergence/Site/IRenderer.php
+++ b/php-classes/Emergence/Site/IRenderer.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Emergence\Site;
+
+
+interface IRenderer
+{
+    public function render(IResponse $response);
+}

--- a/php-classes/Emergence/Site/IResponse.php
+++ b/php-classes/Emergence/Site/IResponse.php
@@ -12,6 +12,6 @@ interface IResponse
     public function setPayload(array $payload);
     public function setPayloadKey($key, $value);
 
-    public function getMode();
-    public function setMode($mode);
+    public function getRenderer();
+    public function setRenderer(IRenderer $renderer);
 }

--- a/php-classes/Emergence/Site/Renderers/Auto.php
+++ b/php-classes/Emergence/Site/Renderers/Auto.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Emergence\Site\Renderers;
+
+use RequestHandler;
+use Emergence\Site\IRenderer;
+use Emergence\Site\IResponse;
+
+class Auto implements IRenderer
+{
+    protected $mode;
+    protected $templatePrefix;
+
+
+    public function __construct($mode = 'html', $templatePrefix = null)
+    {
+        $this->mode = $mode;
+        $this->templatePrefix = $templatePrefix;
+    }
+
+
+    public function getMode()
+    {
+        return $this->mode;
+    }
+
+    public function setMode($mode)
+    {
+        $this->mode = $mode;
+    }
+
+    public function getTemplatePrefix()
+    {
+        return $this->templatePrefix;
+    }
+
+    public function setTemplatePrefix($templatePrefix)
+    {
+        $this->templatePrefix = $templatePrefix;
+    }
+
+
+    public function render(IResponse $response)
+    {
+        $templateId = $response->getId();
+
+        if ($this->templatePrefix) {
+            $templateId = trim($this->templatePrefix, '/').'/'.$templateId;
+        }
+
+        return RequestHandler::respond($templateId, $response->getPayload(), $this->getMode());
+    }
+}

--- a/php-classes/Emergence/Site/Renderers/DwooTemplate.php
+++ b/php-classes/Emergence/Site/Renderers/DwooTemplate.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace Emergence\Site\Renderers;
+
+use Exception;
+
+use Site;
+use SiteFile;
+use Emergence\Dwoo\Engine;
+use Emergence\Dwoo\Template;
+use Emergence\Site\IRenderer;
+use Emergence\Site\IResponse;
+
+class DwooTemplate implements IRenderer
+{
+    protected $template;
+    protected $contentType = 'text/html; charset=utf-8';
+
+
+    public function __construct(Template $template, $contentType = null)
+    {
+        $this->template = $template;
+
+        if ($contentType) {
+            $this->contentType = $contentType;
+        }
+    }
+
+    public static function fromTreeContext($path, $context = null, $contentType = null)
+    {
+        $node = Template::findNode($path, true, $context);
+        return static::fromNode($node, $contentType);
+    }
+
+    public static function fromPath($path, $contentType = null)
+    {
+        if (!$node = Site::resolvePath($path)) {
+            throw new Exception('no node found at template path: '.$path);
+        }
+
+        return static::fromNode($node, $contentType);
+    }
+
+    public static function fromNode(SiteFile $node, $contentType = null)
+    {
+        return new static(new Template($node), $contentType);
+    }
+
+
+    public function getTemplate()
+    {
+        return $this->mode;
+    }
+
+    public function setTemplate(Template $mode)
+    {
+        $this->mode = $mode;
+    }
+
+    public function getContentType()
+    {
+        return $this->contentType;
+    }
+
+    public function setContentType($contentType)
+    {
+        $this->contentType = $contentType;
+    }
+
+
+    public function render(IResponse $response)
+    {
+        header('Content-Type: '.$this->contentType);
+        header('X-Response-ID: '.$response->getId());
+
+        return Engine::respond($this->template, $response->getPayload());
+    }
+}

--- a/php-classes/Emergence/Site/RequestHandler.php
+++ b/php-classes/Emergence/Site/RequestHandler.php
@@ -5,14 +5,10 @@ namespace Emergence\Site;
 
 abstract class RequestHandler extends \RequestHandler implements IRequestHandler
 {
-    public static function sendResponse(IResponse $response, $templatePrefix = null)
+    public static function sendResponse(IResponse $response, IRenderer $renderer = null)
     {
-        $templateId = $response->getId();
+        $renderer = $renderer ?: $response->getRenderer() ?: new Renderers\Auto();
 
-        if ($templatePrefix) {
-            $templateId = trim($templatePrefix, '/').'/'.$templateId;
-        }
-
-        return static::respond($templateId, $response->getPayload(), $response->getMode());
+        return $renderer->render($response);
     }
 }

--- a/php-classes/Emergence/Site/Response.php
+++ b/php-classes/Emergence/Site/Response.php
@@ -10,10 +10,11 @@ class Response implements IResponse
     protected $renderer;
 
 
-    public function __construct($id, array $payload = [])
+    public function __construct($id, array $payload = [], IRenderer $renderer = null)
     {
         $this->id = $id;
         $this->payload = $payload;
+        $this->renderer = $renderer;
     }
 
 

--- a/php-classes/Emergence/Site/Response.php
+++ b/php-classes/Emergence/Site/Response.php
@@ -7,14 +7,13 @@ class Response implements IResponse
 {
     protected $id;
     protected $payload;
-    protected $mode;
+    protected $renderer;
 
 
-    public function __construct($id, array $payload = [], $mode = 'html')
+    public function __construct($id, array $payload = [])
     {
         $this->id = $id;
         $this->payload = $payload;
-        $this->mode = $mode;
     }
 
 
@@ -43,13 +42,13 @@ class Response implements IResponse
         $this->payload[$key] = $value;
     }
 
-    public function getMode()
+    public function getRenderer()
     {
-        return $this->mode;
+        return $this->renderer;
     }
 
-    public function setMode($mode)
+    public function setRenderer(IRenderer $renderer)
     {
-        $this->mode = $mode;
+        $this->renderer = $renderer;
     }
 }

--- a/php-classes/Emergence/WebApps/App.php
+++ b/php-classes/Emergence/WebApps/App.php
@@ -21,7 +21,19 @@ abstract class App implements IApp
 
     final public static function get($name)
     {
-        foreach (static::$types as $type) {
+        // check if there's a keyed type for this app
+        if (!empty(static::$types[$name])) {
+            $type = static::$types[$name];
+            return $type::load($name);
+        }
+
+        // check if any unkeyed type can load the named app
+        foreach (static::$types as $key => $type) {
+            // skip any keyed types
+            if (is_string($key)) {
+                continue;
+            }
+
             if (!is_a($type, IApp::class, true)) {
                 throw new Exception("app type $type does not implement IApp interface");
             }

--- a/php-classes/Emergence/WebApps/App.php
+++ b/php-classes/Emergence/WebApps/App.php
@@ -65,6 +65,10 @@ abstract class App implements IApp
     {
         $node = $this->getAsset($path);
 
+        if (!is_string($path)) {
+            $path = implode('/', $path);
+        }
+
         if (!$node) {
             throw new Exception('asset not found: '.$path);
         }

--- a/php-classes/Emergence/WebApps/IApp.php
+++ b/php-classes/Emergence/WebApps/IApp.php
@@ -6,6 +6,9 @@ namespace Emergence\WebApps;
 interface IApp
 {
     public static function load($appName);
+    /**
+     * @return \Emergence\Site\IResponse
+     */
     public function render();
     public function getName();
     public function getUrl();

--- a/php-classes/Emergence/WebApps/SenchaApp.php
+++ b/php-classes/Emergence/WebApps/SenchaApp.php
@@ -14,6 +14,7 @@ class SenchaApp extends App
 {
     public static $jsSiteEnvironment = [];
     public static $responseId = 'sencha';
+    public static $pluginBuildsRoot = 'webapp-plugin-builds';
     public static $plugins = [];
 
 
@@ -60,6 +61,26 @@ class SenchaApp extends App
         return new Response(static::$responseId, [
             'app' => $this
         ], $renderer);
+    }
+
+    protected function getAsset($path)
+    {
+        if (is_string($path)) {
+            $path = Site::splitPath($path);
+        }
+
+        if ($path[0] && $path[0][0] == '~') {
+            $pluginName = substr(array_shift($path), 1);
+
+            if (!in_array($pluginName, $this->getPlugins())) {
+                throw new Exception('no plugin registered under name: '.$pluginName);
+            }
+
+            array_unshift($path, static::$pluginBuildsRoot, $pluginName);
+            return Site::resolvePath($path);
+        }
+
+        return parent::getAsset($path);
     }
 
     public function buildCssMarkup()
@@ -116,20 +137,14 @@ class SenchaApp extends App
         $html[] = 'Ext.manifest.resources.path = '.json_encode($this->getUrl().'/resources');
         $html[] = '</script>';
 
-        // TODO: migrate away from /app request handler
+        // load plugins
         foreach ($this->getPlugins() as $packageName) {
-            $jsNode = Site::resolvePath(['sencha-workspace', 'packages', $packageName, 'build', "{$packageName}.js"]);
+            $html[] = '<script type="text/javascript" src="'.$this->getAssetUrl("~${packageName}/{$packageName}.js").'"></script>';
 
-            if (!$jsNode) {
-                throw new Exception("build for sencha plugin {$packageName} not found");
-            }
-
-            $html[] = "<script type=\"text/javascript\" src=\"/app/packages/{$packageName}/build/{$jsNode->Handle}?_sha1={$jsNode->SHA1}\"></script>";
-
-            $cssNode = Site::resolvePath(['sencha-workspace', 'packages', $packageName, 'build', 'resources', "{$packageName}-all.css"]);
-
-            if ($cssNode) {
-                $html[] = "<link rel=\"stylesheet\" type=\"text/css\" href=\"/app/packages/{$packageName}/build/resources/{$cssNode->Handle}?_sha1={$cssNode->SHA1}\">";
+            try {
+                $html[] = '<link rel="stylesheet" type="text/css" href="'.$this->getAssetUrl("~${packageName}/resources/{$packageName}-all.css").'">';
+            } catch (Exception $e) {
+                // that's ok, not every plugin has CSS
             }
         }
 

--- a/php-classes/Emergence/WebApps/SenchaApp.php
+++ b/php-classes/Emergence/WebApps/SenchaApp.php
@@ -8,10 +8,12 @@ use Site;
 use Cache;
 use JSON;
 use Emergence\Site\Response;
+use Emergence\Site\Renderers\DwooTemplate;
 
 class SenchaApp extends App
 {
     public static $jsSiteEnvironment = [];
+    public static $responseId = 'sencha';
     public static $plugins = [];
 
 
@@ -53,9 +55,11 @@ class SenchaApp extends App
 
     public function render()
     {
-        return new Response('sencha', [
+        $renderer = DwooTemplate::fromTreeContext('sencha.tpl', ['webapps', $this->name]);
+
+        return new Response(static::$responseId, [
             'app' => $this
-        ]);
+        ], $renderer);
     }
 
     public function buildCssMarkup()

--- a/php-classes/NestingBehavior.class.php
+++ b/php-classes/NestingBehavior.class.php
@@ -100,10 +100,12 @@ class NestingBehavior extends RecordBehavior
         $tableName = $className::$tableName;
 
         // check for orphan collections first
-        $orphanCollections = DB::allValues('ID', 'SELECT c1.ID FROM _e_file_collections c1 LEFT JOIN _e_file_collections c2 ON c2.ID = c1.ParentID WHERE c1.ParentID IS NOT NULL AND c2.ID IS NULL');
+        if ($tableName == '_e_file_collections') {
+            $orphanCollections = DB::allValues('ID', 'SELECT c1.ID FROM _e_file_collections c1 LEFT JOIN _e_file_collections c2 ON c2.ID = c1.ParentID WHERE c1.ParentID IS NOT NULL AND c2.ID IS NULL');
 
-        if (count($orphanCollections)) {
-            throw new Exception('Cannot renest table, orphan collections found: '.implode(',', $orphanCollections));
+            if (count($orphanCollections)) {
+                throw new Exception('Cannot renest table, orphan collections found: '.implode(',', $orphanCollections));
+            }
         }
 
         // compile map

--- a/php-config/Emergence/WebApps/App.config.d/EmergenceContentEditor.php
+++ b/php-config/Emergence/WebApps/App.config.d/EmergenceContentEditor.php
@@ -1,0 +1,3 @@
+<?php
+
+Emergence\WebApps\App::$types['EmergenceContentEditor'] = Emergence\CMS\WebApp::class;

--- a/project-all.sh
+++ b/project-all.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+git holo project emergence-skeleton \
+    --ref=origin/releases/v1 \
+    --commit-to=emergence/skeleton/v1
+
+git holo project emergence-vfs-site \
+    --ref=origin/releases/v1 \
+    --commit-to=emergence/vfs-site/v1
+
+git holo project emergence-vfs-skeleton \
+    --ref=origin/releases/v1 \
+    --commit-to=emergence/vfs-skeleton/v1

--- a/project-all.sh
+++ b/project-all.sh
@@ -1,13 +1,16 @@
 #!/bin/bash
 
 git holo project emergence-skeleton \
+    --fetch \
     --ref=origin/releases/v1 \
     --commit-to=emergence/skeleton/v1
 
 git holo project emergence-vfs-site \
+    --fetch \
     --ref=origin/releases/v1 \
     --commit-to=emergence/vfs-site/v1
 
 git holo project emergence-vfs-skeleton \
+    --fetch \
     --ref=origin/releases/v1 \
     --commit-to=emergence/vfs-skeleton/v1

--- a/site-root/sass/_variables-all.scss
+++ b/site-root/sass/_variables-all.scss
@@ -1,1 +1,2 @@
 @import 'site/variables';       // declare custom colors, fonts, etc. for your site in this file
+@import 'theme/variables';      // bring in theme variables

--- a/site-root/sass/main.scss
+++ b/site-root/sass/main.scss
@@ -5,6 +5,9 @@
 
 @import 'skeleton/common';          // set styles for common elements such as layout, typography, etc.
 
+@import 'theme/common';             // a placeholder for themes to override
+@import 'theme/modules';            // a placeholder for themes to override
+
 @import 'site/common';              // for site-specific overrides or additions that are common across your site
 @import 'site/modules';             // put your site-specific style rules and overrides (other than variables) in here
                                     // variables should go in 'site/variables' above

--- a/site-root/sass/theme/_common.scss
+++ b/site-root/sass/theme/_common.scss
@@ -1,0 +1,1 @@
+// in this file, write theme-specific overrides or additions to skeleton's _common.scss that are common across your themed site

--- a/site-root/sass/theme/_modules.scss
+++ b/site-root/sass/theme/_modules.scss
@@ -1,0 +1,4 @@
+// in this file, import new modules specific to your theme
+// store them in site-root/sass/theme/modules with underscore-prefixed filenames
+// example: /site-root/sass/theme/modules/_snazzy-component.scss can be included here with @import 'modules/snazzy-component';
+// ideally, these modules will have scoped selectors that won't interfere with other styles

--- a/site-tasks/templates/clear-cache.php
+++ b/site-tasks/templates/clear-cache.php
@@ -6,13 +6,16 @@ return [
     'icon' => 'eraser',
     'handler' => function () {
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-            $templateDir = Emergence\Dwoo\Engine::$pathCompile.'/'.Site::getConfig('handle');
+            $templatesDeleted = 0;
+            $templatesDir = Emergence\Dwoo\Engine::getInstance()->getCompileDir().Site::getConfig('handle');
 
-            $filesDeleted = intval(exec("find $templateDir -name \"*.d*.php\" -type f -delete -print | wc -l"));
+            foreach (glob("{$templatesDir}/*.php") as $templatePath) {
+                $templatesDeleted += unlink($templatePath);
+            }
 
             return static::respond('message', [
                 'title' => 'Templates cleared',
-                'message' => "Erased $filesDeleted compiled templates"
+                'message' => "Erased $templatesDeleted compiled templates"
             ]);
         }
 


### PR DESCRIPTION
- feat: add sass hooks for themes
- feat: accept context override for Template::findNode
- feat: enable configuring webapp-specific types by name
- feat: manually resolve renderer+template for sencha webapps
- feat: support loading plugin assets for sencha webapps
- fix: only pre-check collections table when it's being renested
- fix: use $.Site.title instead of label config
- fix: replace use of find for clearing templates
- fix: handle array paths in getAssetUrl
- refactor: implement IRenderer interface for configurable response rendering
- refactor: implement IRenderer interface for configurable response rendering
- chore: add temporary project-all script
- chore: add --fetch to temporary project script
