### PR TITLE
Release: emergence-skeleton v1.7.1

### DIFF
--- a/php-classes/ActiveRecord.class.php
+++ b/php-classes/ActiveRecord.class.php
@@ -2260,6 +2260,7 @@ class ActiveRecord
         // pre-process value
         $forceDirty = false;
         switch ($fieldOptions['type']) {
+            case 'enum':
             case 'clob':
             case 'string':
             {

--- a/php-classes/Emergence/Site/Storage.php
+++ b/php-classes/Emergence/Site/Storage.php
@@ -12,6 +12,22 @@ class Storage
     protected static $filesystems;
 
     /**
+     * Get the root path for all local storage
+     *
+     * @return string $localRootStoragePath
+     */
+    public static function getLocalStorageRoot()
+    {
+        $siteStorageConfig = Site::getConfig('storage');
+
+        if ($siteStorageConfig && !empty($siteStorageConfig['local_root'])) {
+            return $siteStorageConfig['local_root'];
+        }
+
+        return Site::$rootPath.'/site-data';
+    }
+
+    /**
      * Register filesystem for given bucket id
      *
      * @param string $bucketId
@@ -32,7 +48,7 @@ class Storage
     public static function getFilesystem($bucketId)
     {
         if (empty(static::$filesystems[$bucketId])) {
-            $adapter = new LocalAdapter(Site::$rootPath.'/site-data/'.$bucketId);
+            $adapter = new LocalAdapter(static::getLocalStorageRoot().'/'.$bucketId);
             static::$filesystems[$bucketId] = new Filesystem($adapter);
         }
 


### PR DESCRIPTION
- feat: add Storage::getLocalStorageRoot API and use storage.local_root config
- fix: filter enum values as strings when setting (blank means null)