### PR TITLE
Release: emergence-skeleton v1.8.0

### DIFF
--- a/.holo/branches/emergence-site/php-classes/Colors.toml
+++ b/.holo/branches/emergence-site/php-classes/Colors.toml
@@ -1,0 +1,4 @@
+[holomapping]
+holosource = "colors"
+root = "src/Colors"
+files = "**/*.php"

--- a/.holo/sources/colors.toml
+++ b/.holo/sources/colors.toml
@@ -1,0 +1,3 @@
+[holosource]
+url = "https://github.com/kevinlebrun/colors.php.git"
+ref = "refs/heads/master"

--- a/console-commands/connectors/run-job.php
+++ b/console-commands/connectors/run-job.php
@@ -1,0 +1,51 @@
+<?php
+
+use Emergence\Connectors\Job;
+
+$logger = $_COMMAND['LOGGER'];
+
+
+// load template
+if (empty($_COMMAND['ARGS'])) {
+    die('Usage: run-job.php HANDLE');
+}
+
+$TemplateJob = Job::getByHandle($_COMMAND['ARGS']);
+
+if (!$TemplateJob) {
+    $logger->error("Could not find job: $_COMMAND[ARGS]");
+    exit(1);
+}
+
+echo "Loaded template: ";
+dump($TemplateJob->getData());
+echo "\n";
+
+
+// create job from template
+$Job = Job::create([
+    'Connector' => $TemplateJob->Connector,
+    'Template' => $TemplateJob,
+    'Config' => $TemplateJob->Config
+]);
+
+echo "Created job: ";
+dump($Job->getData());
+echo "\n";
+
+
+// create logger
+$Job->setLogger($logger);
+
+
+// reduce error reporting
+error_reporting(E_ALL & ~E_NOTICE);
+
+
+// set time limit
+set_time_limit(0);
+
+
+// start synchronize
+$connectorClass = $Job->Connector;
+$connectorClass::synchronize($Job, false);

--- a/console-commands/connectors/run-job.php
+++ b/console-commands/connectors/run-job.php
@@ -7,7 +7,7 @@ $logger = $_COMMAND['LOGGER'];
 
 // load template
 if (empty($_COMMAND['ARGS'])) {
-    die('Usage: run-job.php HANDLE');
+    die('Usage: connectors:run-job <job-handle>');
 }
 
 $TemplateJob = Job::getByHandle($_COMMAND['ARGS']);

--- a/console-commands/migrations/execute.php
+++ b/console-commands/migrations/execute.php
@@ -1,0 +1,48 @@
+<?php
+
+use Emergence\Connectors\Job;
+use Emergence\SiteAdmin\MigrationsRequestHandler;
+
+$logger = $_COMMAND['LOGGER'];
+
+
+// load migration(s)
+if (empty($_COMMAND['ARGS'])) {
+    die('Usage: migrations:execute <migration-key|--all>');
+}
+
+$migrationKey = $_COMMAND['ARGS'];
+
+if ($migrationKey == '--all') {
+    $migrations = MigrationsRequestHandler::getMigrations();
+} else {
+    $migration = MigrationsRequestHandler::getMigrationData($migrationKey);
+
+    if (!$migration) {
+        $logger->error("Migration not found: $migrationKey");
+        exit(1);
+    }
+
+    $migrations = [ $migration ];
+}
+
+
+// run them all
+foreach ($migrations as $migration) {
+    if ($migration['status'] != MigrationsRequestHandler::STATUS_NEW) {
+        $logger->info('Skipping migration with status {status}: {key}', $migration);
+        continue;
+    }
+
+    $logger->info('Executing migration: {key}', $migration);
+    $migration = MigrationsRequestHandler::executeMigration($migration);
+
+    if ($output = trim($migration['output'])) {
+        $output = explode(PHP_EOL, $output);
+        foreach ($output as $line) {
+            $logger->debug($line);
+        }
+    }
+
+    $logger->notice('Migration complete with result {status}: {key}', $migration);
+}

--- a/console-commands/migrations/execute.php
+++ b/console-commands/migrations/execute.php
@@ -31,7 +31,7 @@ foreach (preg_split('/\s+/', $_COMMAND['ARGS']) as $arg) {
 }
 
 // load migration(s)
-if ($migrationKey == '--all') {
+if ($migrationKeys == '--all') {
     $migrations = MigrationsRequestHandler::getMigrations();
 } else {
     $migrations = [];

--- a/console-commands/test-console.php
+++ b/console-commands/test-console.php
@@ -1,0 +1,37 @@
+<?php
+
+
+// show command data
+echo "\$_COMMAND:\n";
+dump($_COMMAND);
+echo "\n";
+
+
+// show STDIN
+$stdin = file_get_contents('php://input');
+if ($stdin) {
+    echo "STDIN:\n";
+    echo rtrim($stdin);
+    echo "\n\n";
+}
+
+
+// test logger
+$logger = $_COMMAND['LOGGER'];
+
+$logger->emergency('this is an emergency');
+sleep(1);
+$logger->alert('this is an alert');
+sleep(1);
+$logger->critical('this is an critical');
+sleep(1);
+$logger->error('this is an error');
+sleep(1);
+$logger->warning('this is an warning');
+sleep(1);
+$logger->notice('this is an notice');
+sleep(1);
+$logger->info('this is an info');
+sleep(1);
+$logger->debug('this is an debug');
+sleep(1);

--- a/html-templates/connectors/syncronizeComplete.tpl
+++ b/html-templates/connectors/syncronizeComplete.tpl
@@ -52,7 +52,7 @@
                 <dl>
                     {foreach item=delta key=field from=$changes}
                         <dt>{$field}</dt>
-                        <dd>{$delta.from|escape} -> {$delta.to|escape}</dd>
+                        <dd>{default($delta.from, '∅')|escape} &rarr; {default($delta.to, '∅')|escape}</dd>
                     {/foreach}
                 </dl>
             {/if}

--- a/html-templates/connectors/syncronizeComplete.tpl
+++ b/html-templates/connectors/syncronizeComplete.tpl
@@ -41,7 +41,7 @@
     <pre>{$Job->Results|print_r:true}</pre>
 
     <h2>Log</h2>
-    <label><input type="checkbox" onchange="Ext.getBody().down('.sync-log').toggleCls('show-debug', this.checked)">Show debug entries</label>
+    <label><input type="checkbox" onchange="document.querySelector('.sync-log').classList.toggle('show-debug', this.checked)">Show debug entries</label>
     <section class="sync-log">
     {foreach item=entry from=$Job->logEntries}
         <article class="level-{$entry.level}">

--- a/html-templates/exports/exports.tpl
+++ b/html-templates/exports/exports.tpl
@@ -48,5 +48,7 @@
 
             <button>Download</button>
         </form>
+    {foreachelse}
+        <p>No exports are available at your current account level</p>
     {/foreach}
 {/block}

--- a/html-templates/site-admin/migrations/migration.tpl
+++ b/html-templates/site-admin/migrations/migration.tpl
@@ -28,4 +28,11 @@
             </dl>
         </div>
     </div>
+
+    <div class="card mb-3">
+        <div class="card-header">Script output</div>
+        <div class="card-body">
+            <samp style="white-space: pre; display: block" class="p-2">{$migration.output|escape}</samp>
+        </div>
+    </div>
 {/block}

--- a/html-templates/site-admin/migrations/migrationExecuted.tpl
+++ b/html-templates/site-admin/migrations/migrationExecuted.tpl
@@ -30,7 +30,7 @@
             </thead>
 
             <tbody>
-                {foreach item=entry from=$log}
+                {foreach item=entry from=$migration.queryLog}
                     <tr>
                         <td>{$entry.query|escape}</td>
                         <td>{$entry.affected_rows|default:entry.result_rows|number_format}</td>

--- a/html-templates/site-admin/migrations/migrationExecuted.tpl
+++ b/html-templates/site-admin/migrations/migrationExecuted.tpl
@@ -18,13 +18,6 @@
 
     {$dwoo.parent}
 
-    <div class="card mb-3">
-        <div class="card-header">Script output</div>
-        <div class="card-body">
-            <samp style="white-space: pre; display: block" class="p-2">{$output|escape}</samp>
-        </div>
-    </div>
-
     <div class="card">
         <div class="card-header">Query Log</div>
         <table class="card-body table table-striped">

--- a/php-classes/Emergence/Connectors/AbstractConnector.php
+++ b/php-classes/Emergence/Connectors/AbstractConnector.php
@@ -106,7 +106,8 @@ abstract class AbstractConnector extends \RequestHandler implements IConnector
                 return static::throwNotFoundError('Template job not found');
             }
 
-            $Job = Job::create(array(
+            $jobClass = $TemplateJob->Class;
+            $Job = $jobClass::create(array(
                 'Connector' => $TemplateJob->Connector
                 ,'Template' => $TemplateJob
                 ,'Config' => $TemplateJob->Config

--- a/php-classes/Emergence/Console/Logger.php
+++ b/php-classes/Emergence/Console/Logger.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Emergence\Console;
+
+use Colors\Color;
+use Emergence\Logger as EmergenceLogger;
+
+class Logger extends \Psr\Log\AbstractLogger
+{
+    public static $theme = [
+        'debug' => 'dark',
+        'info' => 'default',
+        'notice' => ['default', 'bold'],
+        'warning' => 'yellow',
+        'error' => 'red',
+        'critical' => ['red', 'bold'],
+        'alert' => ['white', 'bg_red'],
+        'emergency' => ['white', 'bg_red', 'bold']
+    ];
+
+    public function log($level, $message, array $context = [])
+    {
+        static $c = null;
+
+        if ($c === null) {
+            $c = new Color;
+            $c->setTheme(static::$theme);
+            $c->setForceStyle(true);
+        }
+
+        $message = EmergenceLogger::interpolate($message, $context);
+        $message = str_replace(PHP_EOL, '⏎', $message);
+
+        echo $c($level.': '.$message)->apply($level).PHP_EOL;
+        flush();
+    }
+}

--- a/php-classes/Emergence/Exports/ExportsRequestHandler.php
+++ b/php-classes/Emergence/Exports/ExportsRequestHandler.php
@@ -70,8 +70,6 @@ class ExportsRequestHandler extends \RequestHandler
 
     public static function handleRequest()
     {
-        $GLOBALS['Session']->requireAccountLevel(static::$accountLevelBrowse);
-
         // execute a selected script
         $scriptPath = array_filter(static::getPath());
 
@@ -80,6 +78,8 @@ class ExportsRequestHandler extends \RequestHandler
         }
 
         // show list of exports
+        $GLOBALS['Session']->requireAccountLevel(static::$accountLevelBrowse);
+
         static::respond('exports', [
             'scripts' => static::getScripts()
         ]);

--- a/php-classes/Emergence/Exports/ExportsRequestHandler.php
+++ b/php-classes/Emergence/Exports/ExportsRequestHandler.php
@@ -14,8 +14,12 @@ use SpreadsheetWriter;
 
 class ExportsRequestHandler extends \RequestHandler
 {
-    public static function getScripts()
+    public static $accountLevelBrowse = 'Staff';
+    public static $accountLevelUseDefault = 'Administrator';
+
+    public static function getScripts($all = false)
     {
+        global $Session;
         static $scripts;
 
         if ($scripts === null) {
@@ -37,6 +41,22 @@ class ExportsRequestHandler extends \RequestHandler
                     throw new Exception("Script $nodePath does not return array");
                 }
 
+                // filter based on account level, unless $all == true
+                if (
+                    !$all
+                    && (
+                        !$Session
+                        || !$Session->hasAccountLevel(
+                            !empty($config['requireAccountLevel'])
+                                ? $config['requireAccountLevel']
+                                : static::$accountLevelUseDefault
+                        )
+                    )
+                ) {
+                    continue;
+                }
+
+                // use readQuery to initialize query if available
                 $config['query'] = is_callable($config['readQuery']) ? call_user_func($config['readQuery'], $_REQUEST, $config) : [];
 
                 $scripts[$path] = $config;
@@ -50,7 +70,7 @@ class ExportsRequestHandler extends \RequestHandler
 
     public static function handleRequest()
     {
-        $GLOBALS['Session']->requireAccountLevel('Administrator');
+        $GLOBALS['Session']->requireAccountLevel(static::$accountLevelBrowse);
 
         // execute a selected script
         $scriptPath = array_filter(static::getPath());
@@ -77,6 +97,13 @@ class ExportsRequestHandler extends \RequestHandler
 
         // load config
         $config = include($scriptNode->RealPath);
+
+        // check account level
+        $GLOBALS['Session']->requireAccountLevel(
+            !empty($config['requireAccountLevel'])
+                ? $config['requireAccountLevel']
+                : static::$accountLevelUseDefault
+        );
 
         // check config
         if (empty($config['buildRows']) || !is_callable($config['buildRows'])) {

--- a/php-classes/Emergence/SiteAdmin/MigrationsRequestHandler.php
+++ b/php-classes/Emergence/SiteAdmin/MigrationsRequestHandler.php
@@ -251,6 +251,7 @@ class MigrationsRequestHandler extends \RequestHandler
                 .',`SHA1` char(40) NOT NULL'
                 .',`Timestamp` timestamp NOT NULL'
                 .',`Status` enum("skipped","started","failed","executed") NOT NULL'
+                .',`Output` TEXT NULL DEFAULT NULL'
                 .',PRIMARY KEY (`Key`)'
             .')'
         );

--- a/php-classes/Emergence/SiteAdmin/MigrationsRequestHandler.php
+++ b/php-classes/Emergence/SiteAdmin/MigrationsRequestHandler.php
@@ -4,7 +4,10 @@ namespace Emergence\SiteAdmin;
 
 use DB;
 use Site;
+use Debug;
 use Emergence_FS;
+use OutOfBoundsException;
+use RangeException;
 use TableNotFoundException;
 use QueryException;
 
@@ -62,95 +65,137 @@ class MigrationsRequestHandler extends \RequestHandler
 
     public static function handleMigrationRequest($migrationKey)
     {
-        $migrationPath = 'php-migrations/'.$migrationKey.'.php';
-        $migrationNode = Site::resolvePath($migrationPath);
-
-        if (!$migrationNode) {
-            return static::throwNotFoundError('Migration not found');
-        }
-
-        try {
-            $migrationRecord = DB::oneRecord('SELECT * FROM _e_migrations WHERE `Key` = "%s"', DB::escape($migrationKey));
-        } catch (TableNotFoundException $e) {
-            $migrationRecord = null;
-        }
-
-        $migration = [
-            'key' => $migrationKey,
-            'path' => $migrationPath,
-            'status' => $migrationRecord ? $migrationRecord['Status'] : static::STATUS_NEW,
-            'executed' => $migrationRecord ? $migrationRecord['Timestamp'] : null,
-            'sha1' => $migrationNode->SHA1,
-            'output' => $migrationRecord ? $migrationRecord['Output'] : null,
-        ];
-
-
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
-            if ($migrationRecord) {
-                return static::throwError('Cannot execute requested migration, it has already been skipped, started, or executed');
-            }
-
-            $insertSql = sprintf('INSERT INTO `_e_migrations` SET `Key` = "%s", SHA1 = "%s", Timestamp = FROM_UNIXTIME(%u), Status = "%s"', $migrationKey, $migrationNode->SHA1, time(), static::STATUS_STARTED);
-
             try {
-                DB::nonQuery($insertSql);
-            } catch (TableNotFoundException $e) {
-                static::createMigrationsTable();
-                DB::nonQuery($insertSql);
-            }
-
-            \Site::$debug = true;
-            $debugLogStartIndex = count(\Debug::$log);
-
-
-            $resetMigrationStatus = function() use ($migrationKey) {
-                static::resetMigrationStatus($migrationKey);
-            };
-
-            ob_start();
-            $migration['status'] = call_user_func(function() use ($migration, $migrationNode, $resetMigrationStatus) {
-                return include($migrationNode->RealPath);
-            });
-            $migration['output'] = ob_get_clean();
-
-            $migration['executed'] = time();
-
-            if ($migration['status'] == static::STATUS_DEBUG) {
-                static::resetMigrationStatus($migrationKey);
-            } else {
-                if (!in_array($migration['status'], [static::STATUS_SKIPPED, static::STATUS_EXECUTED])) {
-                    $migration['status'] = static::STATUS_FAILED;
-                }
-
-                $upgraded = false;
-                do {
-                    try {
-                        DB::nonQuery(
-                            'UPDATE `_e_migrations` SET Timestamp = FROM_UNIXTIME(%u), Status = "%s", Output = "%s" WHERE `Key` = "%s"',
-                            [
-                                $migration['executed'],
-                                $migration['status'],
-                                DB::escape($migration['output']),
-                                $migrationKey,
-                            ]
-                        );
-                        break;
-                    } catch (QueryException $e) {
-                        static::upgradeMigrationsTable();
-                        $upgraded = true;
-                    }
-                } while (!$upgraded);
+                $migration = static::executeMigration($migrationKey);
+            } catch (OutOfBoundsException $e) {
+                return static::throwNotFoundError($e->getMessage());
+            } catch (RangeException $e) {
+                return static::throwInvalidRequestError($e->getMessage());
             }
 
             return static::respond('migrationExecuted', [
-                'migration' => $migration,
-                'log' => array_slice(\Debug::$log, $debugLogStartIndex)
+                'migration' => $migration
             ]);
+        }
+
+        $migration = static::getMigrationData($migrationKey);
+
+        if (!$migration) {
+            return static::throwNotFoundError("Migration not found: {$migrationKey}");
         }
 
         return static::respond('migration', [
             'migration' => $migration
         ]);
+    }
+
+    public static function getMigrationNode($migrationKey)
+    {
+        return Site::resolvePath("php-migrations/{$migrationKey}.php");
+    }
+
+    public static function getMigrationData($migrationKey, array $migrationRecord = null)
+    {
+        $migrationNode = static::getMigrationNode($migrationKey);
+
+        if (!$migrationNode) {
+            return null;
+        }
+
+        if (!$migrationRecord) {
+            try {
+                $migrationRecord = DB::oneRecord('SELECT * FROM _e_migrations WHERE `Key` = "%s"', DB::escape($migrationKey));
+            } catch (TableNotFoundException $e) {
+                $migrationRecord = null;
+            }
+        }
+
+        preg_match('#^(\d{8})(\d*)#', basename($migrationKey), $keyMatches);
+
+        return [
+            'key' => $migrationKey,
+            'path' => $migrationNode->FullPath,
+            'realpath' => $migrationNode->RealPath,
+            'status' => $migrationRecord ? $migrationRecord['Status'] : static::STATUS_NEW,
+            'executed' => $migrationRecord ? $migrationRecord['Timestamp'] : null,
+            'sha1' => $migrationNode->SHA1,
+            'output' => $migrationRecord ? $migrationRecord['Output'] : null,
+            'sequence' => $keyMatches && $keyMatches[1] ? (int)$keyMatches[1] : 0,
+            'sequenceTime' => $keyMatches && $keyMatches[2] ? (int)$keyMatches[2] : 0
+        ];
+    }
+
+    public static function executeMigration($migration)
+    {
+        if (is_string($migration)) {
+            $migrationKey = $migration;
+            $migration = static::getMigrationData($migrationKey);
+
+            if (!$migration) {
+                throw new OutOfBoundsException("Migration not found: {$migrationKey}");
+            }
+        }
+
+        if ($migration['status'] != static::STATUS_NEW) {
+            throw new RangeException('Cannot execute requested migration, it has already been skipped, started, or executed');
+        }
+
+        $insertSql = sprintf('INSERT INTO `_e_migrations` SET `Key` = "%s", SHA1 = "%s", Timestamp = FROM_UNIXTIME(%u), Status = "%s"', $migration['key'], $migration['sha1'], time(), static::STATUS_STARTED);
+
+        try {
+            DB::nonQuery($insertSql);
+        } catch (TableNotFoundException $e) {
+            static::createMigrationsTable();
+            DB::nonQuery($insertSql);
+        }
+
+        Site::$debug = true;
+        $debugLogStartIndex = count(Debug::$log);
+
+
+        $resetMigrationStatus = function() use ($migration) {
+            static::resetMigrationStatus($migration['key']);
+        };
+
+        ob_start();
+        $migration['status'] = call_user_func(function() use ($migration, $resetMigrationStatus) {
+            return include($migration['realpath']);
+        });
+        $migration['output'] = ob_get_clean();
+
+        $migration['executed'] = time();
+
+        if ($migration['status'] == static::STATUS_DEBUG) {
+            static::resetMigrationStatus($migration['key']);
+        } else {
+            if (!in_array($migration['status'], [static::STATUS_SKIPPED, static::STATUS_EXECUTED])) {
+                $migration['status'] = static::STATUS_FAILED;
+            }
+
+            $upgraded = false;
+            do {
+                try {
+                    DB::nonQuery(
+                        'UPDATE `_e_migrations` SET Timestamp = FROM_UNIXTIME(%u), Status = "%s", Output = "%s" WHERE `Key` = "%s"',
+                        [
+                            $migration['executed'],
+                            $migration['status'],
+                            DB::escape($migration['output']),
+                            $migration['key'],
+                        ]
+                    );
+                    break;
+                } catch (QueryException $e) {
+                    static::upgradeMigrationsTable();
+                    $upgraded = true;
+                }
+            } while (!$upgraded);
+        }
+
+        $migration['queryLog'] = array_slice(Debug::$log, $debugLogStartIndex);
+
+        return $migration;
     }
 
     public static function getMigrations()
@@ -175,17 +220,7 @@ class MigrationsRequestHandler extends \RequestHandler
         foreach (Emergence_FS::getTreeFiles('php-migrations') AS $migrationPath => $migrationNodeData) {
             $migrationKey = preg_replace('#^php-migrations/(.*)\.php$#i', '$1', $migrationPath);
             $migrationRecord = array_key_exists($migrationKey, $migrationRecords) ? $migrationRecords[$migrationKey] : null;
-            preg_match('#^(\d{8})(\d*)#', basename($migrationKey), $matches);
-
-            $migrations[$migrationKey] = [
-                'key' => $migrationKey,
-                'path' => 'php-migrations/'.$migrationKey.'.php',
-                'status' => $migrationRecord ? $migrationRecord['Status'] : static::STATUS_NEW,
-                'executed' => $migrationRecord ? $migrationRecord['Timestamp'] : null,
-                'sha1' => $migrationNodeData['SHA1'],
-                'sequence' => $matches && $matches[1] ? (int)$matches[1] : 0,
-                'sequenceTime' => $matches && $matches[2] ? (int)$matches[2] : 0
-            ];
+            $migrations[$migrationKey] = static::getMigrationData($migrationKey, $migrationRecord);
         }
 
         // sort migrations by sequence

--- a/php-classes/Emergence/SiteAdmin/MigrationsRequestHandler.php
+++ b/php-classes/Emergence/SiteAdmin/MigrationsRequestHandler.php
@@ -187,10 +187,14 @@ class MigrationsRequestHandler extends \RequestHandler
                     );
                     break;
                 } catch (QueryException $e) {
+                    if ($upgraded) {
+                        throw $e;
+                    }
+
                     static::upgradeMigrationsTable();
                     $upgraded = true;
                 }
-            } while (!$upgraded);
+            } while (true);
         }
 
         $migration['queryLog'] = array_slice(Debug::$log, $debugLogStartIndex);

--- a/php-classes/SQL.class.php
+++ b/php-classes/SQL.class.php
@@ -3,6 +3,7 @@
 class SQL
 {
     protected static $aggregateFieldConfigs;
+    public static $mysqlStorageEngine = 'MyISAM';
 
     protected static function getAggregateFieldOptions($recordClass, $field = null)
     {
@@ -98,9 +99,10 @@ class SQL
 
 
         $createSQL = sprintf(
-            "CREATE TABLE IF NOT EXISTS `%s` (\n\t%s\n) ENGINE=MyISAM DEFAULT CHARSET=utf8;"
+            "CREATE TABLE IF NOT EXISTS `%s` (\n\t%s\n) ENGINE=%s DEFAULT CHARSET=utf8;"
             , $historyVariant ? $recordClass::getHistoryTableName() : $recordClass::$tableName
             , join("\n\t,", $queryFields)
+            , static::$mysqlStorageEngine
         );
 
         // append history table SQL

--- a/php-migrations/00000000_fix-empty-timestamps.php
+++ b/php-migrations/00000000_fix-empty-timestamps.php
@@ -1,0 +1,64 @@
+<?php
+
+
+// assume migration is skipped until an upgradable value is found
+$skipped = true;
+
+
+// check all timestamp columns
+$timestampColumns = DB::allRecords('
+    SELECT TABLE_NAME,
+           COLUMN_NAME,
+           IS_NULLABLE,
+           COLUMN_TYPE
+      FROM information_schema.`COLUMNS`
+     WHERE TABLE_SCHEMA = SCHEMA()
+       AND DATA_TYPE = "timestamp"
+');
+
+foreach($timestampColumns as $timestampColumn) {
+    $rowsCount = DB::oneValue(
+        'SELECT COUNT(*) FROM `%s` WHERE `%s` = 0',
+        [
+            $timestampColumn['TABLE_NAME'],
+            $timestampColumn['COLUMN_NAME']
+        ]
+    );
+
+    // check if table contains any affected rows
+    if ($rowsCount == 0) {
+        continue;
+    }
+
+    printf("Found %u rows with zero timestamps for `%s`.`%s`\n", $rowsCount, $timestampColumn['TABLE_NAME'], $timestampColumn['COLUMN_NAME']);
+    $skipped = false;
+
+    // reconfigure column to be nullable if needed
+    if ($timestampColumn['IS_NULLABLE'] == 'NO') {
+        printf("Enabling NULL values for `%s`.`%s`\n", $timestampColumn['TABLE_NAME'], $timestampColumn['COLUMN_NAME']);
+
+        DB::nonQuery('SET sql_mode = ""');
+        DB::nonQuery(
+            'ALTER TABLE `%s` MODIFY COLUMN `%s` %s NULL',
+            [
+                $timestampColumn['TABLE_NAME'],
+                $timestampColumn['COLUMN_NAME'],
+                $timestampColumn['COLUMN_TYPE']
+            ]
+        );
+    }
+
+    // patch all zeroed timestamps to NULL
+    printf("Updating %u zero timestamps to NULL for `%s`.`%s`\n", $rowsCount, $timestampColumn['TABLE_NAME'], $timestampColumn['COLUMN_NAME']);
+    DB::nonQuery(
+        'UPDATE `%1$s` SET `%2$s` = NULL WHERE `%2$s` = 0',
+        [
+            $timestampColumn['TABLE_NAME'],
+            $timestampColumn['COLUMN_NAME']
+        ]
+    );
+}
+
+
+// done
+return $skipped ? static::STATUS_SKIPPED : static::STATUS_EXECUTED;

--- a/php-migrations/Emergence/People/20140426_add-middle-name.php
+++ b/php-migrations/Emergence/People/20140426_add-middle-name.php
@@ -1,0 +1,28 @@
+<?php
+
+$tableName = Person::$tableName;
+$historyTableName = Person::getHistoryTableName();
+$columnName = 'MiddleName';
+
+
+// skip conditions
+if (!static::tableExists($tableName)) {
+    printf("Skipping migration because table `%s` does not exist yet\n", $tableName);
+    return static::STATUS_SKIPPED;
+}
+
+if (static::columnExists($tableName, $columnName)) {
+    printf("Skipping migration because column `%s` already exists in table `%s`\n", $columnName, $tableName);
+    return static::STATUS_SKIPPED;
+}
+
+
+
+// migration
+printf("Adding column `%s` to table `%s`\n", $columnName, $tableName);
+DB::nonQuery('ALTER TABLE `%s` ADD `%s` VARCHAR(255) NULL default NULL AFTER `LastName`', [$tableName, $columnName]);
+DB::nonQuery('ALTER TABLE `%s` ADD `%s` VARCHAR(255) NULL default NULL AFTER `LastName`', [$historyTableName, $columnName]);
+
+
+// done
+return static::STATUS_EXECUTED;


### PR DESCRIPTION
- feat: add support for alternate mysql engines
- feat: add colored console logger
- feat: add test-console console command
- feat: add connectors:run-job console command
- feat: add migration output logging
- feat: add migrations:execute console command
- feat: configurable account levels for exports
- feat: render null and arrow in log with characters
- feat: add --force option for migrations:execute
- feat: add universal timestamp cleanup migration
- fix: carry class when cloning template job
- fix: add middlename migration for very old databases
- refactor: use File class for hardened MIME detection
- refactor: modularize migrations handler
- refactor: use vanilla js for sync log