### PR TITLE
Release: emergence-skeleton v1.8.1

### DIFF
--- a/.github/workflows/holo.yml
+++ b/.github/workflows/holo.yml
@@ -37,7 +37,7 @@ jobs:
           --silent \
           -H "Authorization: Token ${VFS_DEV_TOKEN}" \
           -H "Accept: application/json" \
-          "http://skeleton-v1.emr.ge/site-admin/sources/emergence-skeleton-v1/pull" \
+          "http://skeleton-v1.emr.ge/site-admin/sources/emergence-skeleton-v1/pull?fetch=true" \
           | jq '.'
 
         # sync VFS to git

--- a/php-classes/Emergence/Git/Source.php
+++ b/php-classes/Emergence/Git/Source.php
@@ -403,7 +403,7 @@ class Source
         $output = trim($this->getRepository()->run('merge', ['--ff-only', '--no-stat', '@{upstream}']));
         $output = explode(PHP_EOL, $output);
 
-        if ($output[0] == 'Already up-to-date.') {
+        if ($output[0] == 'Already up-to-date.' || $output[0] == 'Already up to date.') {
             return false;
         }
 

--- a/php-classes/Emergence/Git/Source.php
+++ b/php-classes/Emergence/Git/Source.php
@@ -410,7 +410,7 @@ class Source
         list ($status, $commits) = explode(' ', $output[0]);
 
         if ($status != 'Updating') {
-            throw new \Exception('Unexpected merge status output: ' . $status);
+            throw new \Exception("Unexpected merge status output '{$status}' from line: {$output[0]}");
         }
 
         list ($from, $to) = explode('..', $commits);

--- a/php-classes/Emergence/SiteAdmin/SourcesRequestHandler.php
+++ b/php-classes/Emergence/SiteAdmin/SourcesRequestHandler.php
@@ -169,6 +169,10 @@ class SourcesRequestHandler extends \RequestHandler
             ]);
         }
 
+        if (!empty($_REQUEST['fetch'])) {
+            $source->fetch();
+        }
+
         $result = $source->pull();
 
         return static::respondStatusMessage($source, $result ? "Updated local branch from commit $result[from] to upstream commit $result[to]" : 'Local branch already up-to-date');


### PR DESCRIPTION
- fix: fetch when invoking source pull via GH Action
- fix: improve exception output on pull error
- fix: detect git 'Already up to date' message without hyphens