### PR TITLE
fix/upgrade degradations

### DIFF
--- a/html-templates/site-admin/tasks/configuration/degradations.tpl
+++ b/html-templates/site-admin/tasks/configuration/degradations.tpl
@@ -3,7 +3,7 @@
 {block content}
     {if $changes}
         <div class="alert alert-info" role="alert">
-            <strong>Updated degredations:</strong>
+            <strong>Updated degradations:</strong>
             <ul>
             {foreach item=value key=key from=$changes}
                 <li>{$key|escape}: {tif $value ? 'on' : 'off'}</li>
@@ -13,14 +13,14 @@
     {/if}
 
     <form method="POST" class="card">
-        <div class="card-header">Configured degredations</div>
+        <div class="card-header">Configured degradations</div>
 
         <div class="card-body">
-            {foreach item=value key=key from=$degredations}
-                <input type="hidden" name="degredations[{$key|escape}]" value="off">
+            {foreach item=value key=key from=$degradations}
+                <input type="hidden" name="degradations[{$key|escape}]" value="off">
                 <div class="checkbox">
                     <label>
-                        <input type="checkbox" name="degredations[{$key|escape}]" value="on" {tif $value ? checked}>
+                        <input type="checkbox" name="degradations[{$key|escape}]" value="on" {tif $value ? checked}>
                         {$key|escape}
                     </label>
                 </div>
@@ -30,7 +30,7 @@
                 <input type="text" placeholder="new-key" name="enable[]">
             </div>
 
-            <button type="submit" class="btn btn-primary">Apply Degredations</button>
+            <button type="submit" class="btn btn-primary">Apply Degradations</button>
         </div>
     </form>
 {/block}

--- a/php-classes/Emergence/Dwoo/Engine.php
+++ b/php-classes/Emergence/Dwoo/Engine.php
@@ -114,7 +114,7 @@ class Engine extends \Dwoo_Core
         // set site information
         $this->globals['Site'] = array(
             'title' => Site::$title
-            ,'degredations' => Site::getConfig('degredations')
+            ,'degradations' => Site::getConfig('degradations')
         );
 
         // add magic globals

--- a/site-tasks/configuration/degradations.php
+++ b/site-tasks/configuration/degradations.php
@@ -1,19 +1,19 @@
 <?php
 
 return [
-    'title' => 'Manage Degredations',
+    'title' => 'Manage Degradations',
     'description' => 'Enable or disable degredation flags that can be used to reduce the functionality of sites live while under failure or high load',
     'icon' => 'power-off',
     'handler' => function () {
         $config = Site::getConfig();
-        $degredations = !empty($config['degredations']) ? $config['degredations'] : [];
+        $degradations = !empty($config['degradations']) ? $config['degradations'] : [];
         $changes = [];
 
         if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
             // parse degredation changes from request input
-            if (!empty($_POST['degredations']) && is_array($_POST['degredations'])) {
-                foreach ($_POST['degredations'] AS $key => $value) {
+            if (!empty($_POST['degradations']) && is_array($_POST['degradations'])) {
+                foreach ($_POST['degradations'] AS $key => $value) {
                     if ($key && is_string($key)) {
                         $changes[$key] = $value == 'on';
                     }
@@ -37,26 +37,26 @@ return [
             }
 
 
-            // apply degredations
+            // apply degradations
             if (count($changes)) {
                 foreach ($changes AS $key => $value) {
-                    if (isset($degredations[$key]) && $degredations[$key] == $value) {
+                    if (isset($degradations[$key]) && $degradations[$key] == $value) {
                         unset($changes[$key]);
                         continue;
                     }
 
-                    $degredations[$key] = $value;
+                    $degradations[$key] = $value;
                 }
 
-                $config['degredations'] = $degredations;
+                $config['degradations'] = $degradations;
 
                 // update cached site config
                 Cache::rawStore(Site::$rootPath, $config);
             }
         }
-        
-        return static::respond('degredations', [
-            'degredations' => $degredations,
+
+        return static::respond('degradations', [
+            'degradations' => $degradations,
             'changes' => $changes
         ]);
     }


### PR DESCRIPTION
-  refactor: fix spelling of degradations
- [ ] make compatible with Habitat-hosted sites (site config is statically injected rather than loaded from cache, so updating cache won't persist values)
  - move to own cache namespace that's only initialized from config?