### PR TITLE
feat: add docs site

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,0 +1,19 @@
+name: Publish Website
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  publish-website:
+    runs-on: ubuntu-latest
+    steps:
+    - name: 'Update holobranch: gh-pages'
+      uses: JarvusInnovations/hologit@actions/projector/v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        HAB_LICENSE: accept
+      with:
+        holobranch: docs-site
+        commit-to: gh-pages

--- a/.holo/branches/docs-site.lenses/mkdocs.toml
+++ b/.holo/branches/docs-site.lenses/mkdocs.toml
@@ -1,0 +1,11 @@
+[hololens]
+package = "holo/lens-mkdocs"
+requirements = [
+    "mkdocs-material",
+    "mkdocs-awesome-pages-plugin",
+    "fontawesome_markdown",
+    "mdx_truly_sane_lists"
+]
+
+[hololens.output]
+merge = "replace"

--- a/.holo/branches/docs-site/_skeleton-v1.toml
+++ b/.holo/branches/docs-site/_skeleton-v1.toml
@@ -1,0 +1,5 @@
+[holomapping]
+files = [
+    "docs/",
+    "mkdocs.yml"
+]

--- a/.holo/branches/docs-skeleton.toml
+++ b/.holo/branches/docs-skeleton.toml
@@ -1,0 +1,3 @@
+[holobranch]
+extend = "docs-site"
+lens = false

--- a/.studiorc
+++ b/.studiorc
@@ -1,4 +1,25 @@
 #!/bin/bash
 
-hab pkg install emergence/studio
+# install dependent studios
+hab pkg install emergence/studio jarvus/mkdocs-studio
+
+
+# disable studios printing their own help
+export STUDIO_NOHELP="yes"
+
+
+# load emergence studio
 source "$(hab pkg path emergence/studio)/studio.sh"
+
+
+# load mkdocs studio
+export DOCS_HOLOBRANCH="docs-site"
+source "$(hab pkg path jarvus/mkdocs-studio)/studio.sh"
+
+
+## final init and output
+studio-help
+
+
+# final blank line
+echo

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Site Documentation
+
+Welcome, browse sections at the top of the site.

--- a/docs/development/migrations.md
+++ b/docs/development/migrations.md
@@ -1,0 +1,22 @@
+# Developing Migrations
+
+Within the development studio:
+
+1. Create a new file under `php-migrations/`
+2. Load modified working tree into runtime:
+
+    ```bash
+    update-site
+    ```
+
+3. Execute all migrations:
+
+    ```bash
+    console-run migrations:execute --all
+    ```
+
+4. (Re)Execute a specific migration:
+
+    ```bash
+    console-run migrations:execute --force "Emergence/People/20191209_system-user"
+    ```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,43 @@
+site_name: Skeleton Docs
+site_url: https://jarvusinnovations.github.io/emergence-skeleton
+edit_uri: edit/develop/docs
+
+theme:
+  name: material
+  features:
+    - navigation.tabs
+  palette:
+    primary: "orange"
+    accent: "red"
+
+plugins:
+  - search
+  - awesome-pages
+
+extra_javascript:
+  - https://unpkg.com/mermaid@8.5.0/dist/mermaid.min.js
+
+extra_css:
+  - https://use.fontawesome.com/releases/v5.13.0/css/all.css
+
+markdown_extensions:
+  - admonition
+  - codehilite:
+      linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tabbed
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_div_format
+  - pymdownx.smartsymbols
+  - meta
+  - toc:
+      # insert a blank space before the character
+      permalink: " ¶"
+  - smarty
+  - fontawesome_markdown
+  - mdx_truly_sane_lists

--- a/script/-studio-bootstrap
+++ b/script/-studio-bootstrap
@@ -1,0 +1,91 @@
+#!/bin/bash
+
+# script/-studio-bootstrap: Check dependencies for Chef Habitat studio.
+
+set -e
+cd "$(dirname "$0")/.."
+
+
+echo
+echo "==> studio-bootstrap: verifying Docker…"
+
+if ! [ -x "$(command -v docker)" ]; then
+    echo "Please install Docker Engine: https://docs.docker.com/engine/install/"
+    exit 1
+fi
+
+if ! docker info > /dev/null 2>&1; then
+    echo "Docker Engine is not running, or your user does not have access to connect."
+    echo "Try starting Docker Engine, and adding your user to the docker group: sudo gpasswd -a $USER docker"
+    exit 1
+fi
+
+
+echo
+echo "==> studio-bootstrap: verifying Chef Habitat…"
+
+if ! [ -x "$(command -v hab)" ]; then
+    echo "Please install Chef Habitat: https://www.habitat.sh/docs/install-habitat/"
+    exit 1
+fi
+
+set +e
+hab_version="$(hab --version < /dev/null)"
+if [ $? -ne 0 ]; then
+    echo
+    echo "   Failed to read hab version, you may need to accept the Chef Habitat"
+    echo "   license. Please run \`hab setup\` or configure HAB_LICENSE in the environment"
+    exit 1
+fi
+set -e
+
+if ! [[ $hab_version =~ ^hab[[:space:]][0-9]+\.[0-9]+\.[0-9]+/[0-9]+$ ]]; then
+    echo
+    echo "    Could not parse hab version: ${hab_version}"
+    echo "    Please install hab 1.6+"
+    exit 1
+fi
+
+hab_version="$(echo "${hab_version}" | awk '{print $2}' | awk -F'/' '{print $1}')"
+echo "    Found hab version: ${hab_version}"
+
+
+# check that node >= MAJOR.MINOR
+hab_min_major="1"
+hab_min_minor="6"
+
+IFS='.' read -ra hab_version_split <<< "${hab_version#v}"
+if [ "${hab_version_split[0]}" -lt "${hab_min_major}" ] || [[ "${hab_version_split[0]}" -le "${hab_min_major}" && "${hab_version_split[1]}" -lt "${hab_min_minor}" ]]; then
+    echo
+    echo "     Please install hab >= ${hab_min_major}.${hab_min_minor}.x"
+    exit 1
+fi
+
+if ! [ -f ~/.hab/etc/cli.toml ] || ! grep -q '^origin =' ~/.hab/etc/cli.toml; then
+    echo "Please re-run \`hab setup\` and choose to set a default origin, it can be anything"
+    exit 1
+fi
+
+_origin=$(awk -F'"' '/^origin = /{print $2}' ~/.hab/etc/cli.toml)
+
+
+echo
+echo "==> studio-bootstrap: verifying origin '${_origin}'…"
+
+_root_owned_key_count=$(ls -l ~/.hab/cache/keys | cut -f 3,4 -d " " | grep "root root" | wc -l)
+
+if [ "$_root_owned_key_count" -gt 0 ]; then
+    echo "Working around: https://github.com/habitat-sh/habitat/issues/7737"
+    echo "Found ${_root_owned_key_count} keys owned by root. Chowning them to $USER:$USER."
+    sudo chown $USER:$USER ~/.hab/cache/keys/*
+fi
+
+if ! hab origin key export --type secret "${_origin}" > /dev/null; then
+    echo "No key has been generated for origin ${_origin}, run: hab origin key generate ${_origin}"
+    exit 1
+fi
+
+
+echo
+echo "==> studio-bootstrap: all set 👍"
+echo

--- a/script/studio
+++ b/script/studio
@@ -1,0 +1,67 @@
+#!/bin/sh
+
+# script/studio: Enter a Chef Habitat studio for the application.
+
+set -e
+cd "$(dirname "$0")/.."
+
+
+script/-studio-bootstrap
+
+
+unset DEBUG
+[ -n "${1}" ] && cd "${1}"
+
+
+echo
+echo "==> studio: configuring Chef Habitat studio Docker options…"
+STUDIO_NAME="${STUDIO_NAME:-skeleton-studio}"
+export HAB_DOCKER_OPTS="
+    --name ${STUDIO_NAME}
+    -p 7080:80
+    -p 7088:8000
+    -p 7036:3306
+    -v $(cd ~/.ssh; pwd)/known_hosts:/root/.ssh/known_hosts:ro
+    --env STUDIO_DEVELOPER_UID=$(id -u)
+    --env STUDIO_DEVELOPER_GID=$(id -g)
+"
+echo "${HAB_DOCKER_OPTS}"
+
+
+launch_studio=true
+if [ "$(docker ps -aq -f name="${STUDIO_NAME}")" ]; then
+    echo
+    echo "==> studio: a ${STUDIO_NAME} container is already running…"
+    echo
+    while true; do
+        read -p "==> studio: would you like to (A)ttach to it, (s)top it, or do (n)othing? [A/s/n] " choice
+        case "${choice}" in
+        r|R|a|A|"")
+            echo
+            echo "==> studio: you can run studio-help at anytime to get a list of commands"
+            echo
+            docker attach "${STUDIO_NAME}"
+            launch_studio=false
+            break;;
+        s|S)
+            echo "==> studio: stopping existing container…"
+            docker stop "${STUDIO_NAME}" > /dev/null
+            break;;
+        n|N)
+            echo "==> studio: doing nothing with existing container… an error is likely to occur"
+            break ;;
+        *)
+            echo "==> studio: $choice is invalid";;
+        esac
+    done
+fi
+
+if [ $launch_studio = true ]; then
+    echo
+    echo "==> studio: launching Docker-powered Chef Habitat studio…"
+    set +e
+    if ! hab studio enter -D; then
+        echo "===> studio: failed to launch studio… try executing the following and try again:"
+        echo "docker rm -f ${STUDIO_NAME}"
+    fi
+fi


### PR DESCRIPTION
## Why

Need a place to document workflows that evolve as part of skeleton, and should be easy to include in sub-project documentation

## What

- Add standard `script/studio` developer command
- Configure mkdocs site, with holobranch and gh-pages projection
- Configure un-lensed `docs-skeleton` projection for sub-projects to build on
- Add an initial docs page on developing migrations