### PR TITLE
Fixes/tag items

### DIFF
--- a/php-classes/TagItem.class.php
+++ b/php-classes/TagItem.class.php
@@ -148,12 +148,14 @@ class TagItem extends ActiveRecord
         }
 
         if (isset($classSubquery)) {
+            $classIDs = DB::allValues('ID', $classSubquery, $classParams);
+
             $itemsCountQuery .= sprintf(
                 ' AND TagItem.`%s` = "%s" AND TagItem.`%s` IN (%s)'
                 ,TagItem::getColumnName('ContextClass')
                 ,$options['Class']::getStaticRootClass()
                 ,TagItem::getColumnName('ContextID')
-                ,DB::prepareQuery($classSubquery, $classParams)
+                ,implode(",",$classIDs)
             );
         }
 

--- a/php-classes/TagItem.class.php
+++ b/php-classes/TagItem.class.php
@@ -153,7 +153,7 @@ class TagItem extends ActiveRecord
             $itemsCountQuery .= sprintf(
                 ' AND TagItem.`%s` = "%s" AND TagItem.`%s` IN (%s)'
                 ,TagItem::getColumnName('ContextClass')
-                ,$options['Class']::getStaticRootClass()
+                ,DB::escape($options['Class']::getStaticRootClass())
                 ,TagItem::getColumnName('ContextID')
                 ,implode(",",$classIDs)
             );

--- a/php-classes/TagItem.class.php
+++ b/php-classes/TagItem.class.php
@@ -132,7 +132,7 @@ class TagItem extends ActiveRecord
 
         if (!empty($options['overlayTag'])) {
             if (!is_object($OverlayTag = $options['overlayTag']) && !$OverlayTag = Tag::getByHandle($options['overlayTag'])) {
-                throw new Excoption('Overlay tag not found');
+                throw new Exception('Overlay tag not found');
             }
 
             $itemsCountQuery .= sprintf(


### PR DESCRIPTION
This contains the performance enhancement to TagItems discussed with @themightychris in 9d006cd2dc2859cfc1add194e50a2bd7b4822dfe .  

Also, I discovered a bug where the class name was not being correctly translated from string to query and I added escape to that line here: ab8b5120eb1ac5595f1bef8477009f80a6398075 .  This fix is necessary for the latest tag browsing updates made to Slate.