### PR TITLE
fix: allow account level to be set when calling index handler

### DIFF
--- a/php-classes/Emergence/RequestHandler/IndexRequestHandler.php
+++ b/php-classes/Emergence/RequestHandler/IndexRequestHandler.php
@@ -22,7 +22,7 @@ class IndexRequestHandler extends AbstractRequestHandler
     public static function handleIndexRequest($requiredAccountLevel = 'Administrator', $path = null)
     {
         if ($requiredAccountLevel) {
-            $GLOBALS['Session']->requireAccountLevel('Administrator');
+            $GLOBALS['Session']->requireAccountLevel($requiredAccountLevel);
         }
 
         if ($path === null) {


### PR DESCRIPTION
This looks like an oversight.  The index handler accepts a $requiredAccountLevel parameter, but it was not being used and the auth level for all index requests was set to 'Administrator'.   The auth level is now set to the level specified by the $requiredAccountLevel parameter, if sent.  If a parameter is not sent, it defaults to 'Administrator' so I do not believe this will affect existing code.