### PR TITLE
fix(activerecord): explicitly set null value should not be replaced with default

### DIFF
--- a/php-classes/ActiveRecord.class.php
+++ b/php-classes/ActiveRecord.class.php
@@ -2227,7 +2227,14 @@ class ActiveRecord
                     return $value;
                 }
             }
-        } elseif ($useDefault && isset($fieldOptions['default'])) {
+        } elseif (
+            $useDefault
+            && isset($fieldOptions['default'])
+            && (
+                $fieldOptions['notnull']
+                || !array_key_exists($fieldOptions['columnName'], $this->_record)
+            )
+        ) {
             // return default
             return $fieldOptions['default'];
         } else {

--- a/phpunit-tests/emergence.read-only/ActiveRecordTest.php
+++ b/phpunit-tests/emergence.read-only/ActiveRecordTest.php
@@ -10,6 +10,14 @@ final class ActiveRecordTest extends PHPUnit\Framework\TestCase
     public function testFields(): void
     {
         $fields = TestRecord::getClassFields();
-        $this->assertEquals(array_keys($fields), array('ID', 'Class', 'Created', 'CreatorID', 'Field1', 'Field2'), 'check class fields list');
+        $this->assertEquals(array_keys($fields), array('ID', 'Class', 'Created', 'CreatorID', 'Field1', 'Field2', 'NullableDefault'), 'check class fields list');
+    }
+
+    public function testDefaults(): void
+    {
+        $Record = new TestRecord();
+        $this->assertEquals(1, $Record->NullableDefault, 'unset value returns default');
+        $this->assertNull($Record->NullableDefault = null, 'value set to null');
+        $this->assertNull($Record->NullableDefault, 'value previously set explicitely to null returns null');
     }
 }

--- a/phpunit-tests/emergence.read-only/ActiveRecordTest.php
+++ b/phpunit-tests/emergence.read-only/ActiveRecordTest.php
@@ -10,14 +10,21 @@ final class ActiveRecordTest extends PHPUnit\Framework\TestCase
     public function testFields(): void
     {
         $fields = TestRecord::getClassFields();
-        $this->assertEquals(array_keys($fields), array('ID', 'Class', 'Created', 'CreatorID', 'Field1', 'Field2', 'NullableDefault'), 'check class fields list');
+        $this->assertEquals(array_keys($fields), array('ID', 'Class', 'Created', 'CreatorID', 'Field1', 'Field2', 'NullableDefault', 'NotNullableDefault'), 'check class fields list');
     }
 
     public function testDefaults(): void
     {
         $Record = new TestRecord();
-        $this->assertEquals(1, $Record->NullableDefault, 'unset value returns default');
-        $this->assertNull($Record->NullableDefault = null, 'value set to null');
-        $this->assertNull($Record->NullableDefault, 'value previously set explicitely to null returns null');
+
+        $this->assertEquals(1, $Record->NullableDefault, 'unset nullable value returns default');
+        $this->assertNull($Record->NullableDefault = null, 'nullable value set to null');
+        $this->assertNull($Record->NullableDefault, 'nullable value previously set explicitely to null returns null');
+
+        $this->assertEquals(1, $Record->NotNullableDefault, 'unset non-nullable value returns default');
+        $this->assertNull($Record->NotNullableDefault = null, 'non-nullable value set to null');
+        $this->assertEquals(0, $Record->NotNullableDefault, 'non-nullable value previously set explicitely to null returns null');
+        $this->assertEquals(1, $Record->NotNullableDefault = 1, 'non-nullable value set to 1');
+        $this->assertEquals(1, $Record->NotNullableDefault, 'non-nullable value previously set explicitely to 1 returns 1');
     }
 }

--- a/phpunit-tests/emergence.read-only/src/TestRecord.php
+++ b/phpunit-tests/emergence.read-only/src/TestRecord.php
@@ -9,6 +9,11 @@ class TestRecord extends ActiveRecord
             'type' => 'int',
             'notnull' => false,
             'default' => 1
+        ),
+        'NotNullableDefault' => array(
+            'type' => 'int',
+            'notnull' => true,
+            'default' => 1
         )
     );
 }

--- a/phpunit-tests/emergence.read-only/src/TestRecord.php
+++ b/phpunit-tests/emergence.read-only/src/TestRecord.php
@@ -4,6 +4,11 @@ class TestRecord extends ActiveRecord
 {
     public static $fields = array(
         'Field1',
-        'Field2'
+        'Field2',
+        'NullableDefault' => array(
+            'type' => 'int',
+            'notnull' => false,
+            'default' => 1
+        )
     );
 }


### PR DESCRIPTION
Fixes a bug where a nullable field with a non-null default configured will return the default value even after it has been explicitly set to `null`.